### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webui_test.yaml
+++ b/.github/workflows/webui_test.yaml
@@ -1,4 +1,6 @@
 name: WebUI Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lordmathis/llamactl/security/code-scanning/1](https://github.com/lordmathis/llamactl/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since this workflow only checks out code and runs tests (no deployment, no issue or PR modification), it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow (just after the `name:` line and before `on:`), so it applies to all jobs in the workflow. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
