### PR TITLE
fix: llamactl reads config file per documentation

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -216,6 +217,7 @@ func loadConfigFile(cfg *AppConfig, configPath string) error {
 			if err := yaml.Unmarshal(data, cfg); err != nil {
 				return err
 			}
+			log.Printf("Read config at %s", path)
 			return nil
 		}
 	}
@@ -475,6 +477,10 @@ func getDefaultDataDirectory() string {
 // getDefaultConfigLocations returns platform-specific config file locations
 func getDefaultConfigLocations() []string {
 	var locations []string
+	// Use ./llamactl.yaml and ./config.yaml as the default config file
+	locations = append(locations, "llamactl.yaml")
+	locations = append(locations, "config.yaml")
+
 	homeDir, _ := os.UserHomeDir()
 
 	switch runtime.GOOS {


### PR DESCRIPTION
In [docs/getting-started/configuration.md](https://github.com/lordmathis/llamactl/blob/a824f066ecb264d86346eb016a458eed841b1b16/docs/getting-started/configuration.md?plain=1#L75)

> Configuration files are searched in the following locations (in order of precedence):
> 
> **Linux:**  
> - `./llamactl.yaml` or `./config.yaml` (current directory)

But `llamactl` does not read these files

- llamactl now properly reads config files from the expected locations ("llamactl.yaml" and "config.yaml" under current directory)
- Added additional logging to track which config file is read