### PR TITLE
fix: InstancesDir and LogsDir not being relative path to DataDir when not set

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -166,10 +166,12 @@ func LoadConfig(configPath string) (AppConfig, error) {
 			},
 		},
 		Instances: InstancesConfig{
-			PortRange:            [2]int{8000, 9000},
-			DataDir:              getDefaultDataDirectory(),
-			InstancesDir:         filepath.Join(getDefaultDataDirectory(), "instances"),
-			LogsDir:              filepath.Join(getDefaultDataDirectory(), "logs"),
+			PortRange: [2]int{8000, 9000},
+			DataDir:   getDefaultDataDirectory(),
+			// NOTE: empty strings are set as placeholder values since InstancesDir and LogsDir
+			// should be relative path to DataDir if not explicitly set.
+			InstancesDir:         "",
+			LogsDir:              "",
 			AutoCreateDirs:       true,
 			MaxInstances:         -1, // -1 means unlimited
 			MaxRunningInstances:  -1, // -1 means unlimited
@@ -196,6 +198,14 @@ func LoadConfig(configPath string) (AppConfig, error) {
 
 	// 3. Override with environment variables
 	loadEnvVars(&cfg)
+
+	// If InstancesDir or LogsDir is not set, set it to relative path of DataDir
+	if cfg.Instances.InstancesDir == "" {
+		cfg.Instances.InstancesDir = filepath.Join(cfg.Instances.DataDir, "instances")
+	}
+	if cfg.Instances.LogsDir == "" {
+		cfg.Instances.LogsDir = filepath.Join(cfg.Instances.DataDir, "logs")
+	}
 
 	return cfg, nil
 }


### PR DESCRIPTION
InstancesDir and LogsDir are always set to something like `~/.local/share/llamactl/instances` and `~/.local/share/llamactl/logs` because the default values are prefilled by the default instance.

This causes an issue where a user sets only `DataDir` (data_dir) and expects the `InstancesDir` and `LogsDir` to be sub-directories of `DataDir` as stated in [docs/getting-started/configuration.md](https://github.com/lordmathis/llamactl/blob/f9371e876d534b55777e1eb5933b96983431ff83/docs/getting-started/configuration.md?plain=1#L152).

```
instances:
  ...
  data_dir: "~/.local/share/llamactl"               # Directory for all llamactl data (default varies by OS)
  configs_dir: "~/.local/share/llamactl/instances"  # Directory for instance configs (default: data_dir/instances)
  logs_dir: "~/.local/share/llamactl/logs"          # Directory for instance logs (default: data_dir/logs)
```

I've updated the code to set `InstancesDir` and `LogsDir` to the proper relative path `DataDir` of if they remain unset (empty string).