### PR TITLE
Added support for serving behind a reverse proxy

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -122,6 +122,7 @@ backends:
       image: "ghcr.io/ggml-org/llama.cpp:server"
       args: ["run", "--rm", "--network", "host", "--gpus", "all"]
       environment: {}
+    response_headers: {}               # Additional response headers to send with responses
 
   vllm:
     command: "vllm"
@@ -132,23 +133,28 @@ backends:
       image: "vllm/vllm-openai:latest"
       args: ["run", "--rm", "--network", "host", "--gpus", "all", "--shm-size", "1g"]
       environment: {}
+    response_headers: {}               # Additional response headers to send with responses
 
   mlx:
     command: "mlx_lm.server"
     args: []
     environment: {}                    # Environment variables for the backend process
     # MLX does not support Docker
+    response_headers: {}               # Additional response headers to send with responses
 ```
 
 **Backend Configuration Fields:**
 - `command`: Executable name/path for the backend
 - `args`: Default arguments prepended to all instances
 - `environment`: Environment variables for the backend process (optional)
+- `response_headers`: Additional response headers to send with responses (optional)
 - `docker`: Docker-specific configuration (optional)
   - `enabled`: Boolean flag to enable Docker runtime
   - `image`: Docker image to use
   - `args`: Additional arguments passed to `docker run`
   - `environment`: Environment variables for the container (optional)
+
+> If llamactl is behind an nginx proxy, `X-Accel-Buffering: no` may be required for nginx to properly stream the responses without buffering.
 
 **Environment Variables:**
 
@@ -160,6 +166,7 @@ backends:
 - `LLAMACTL_LLAMACPP_DOCKER_IMAGE` - Docker image to use
 - `LLAMACTL_LLAMACPP_DOCKER_ARGS` - Space-separated Docker arguments
 - `LLAMACTL_LLAMACPP_DOCKER_ENV` - Docker environment variables in format "KEY1=value1,KEY2=value2"
+- `LLAMACTL_LLAMACPP_RESPONSE_HEADERS` - Response headers in format "KEY1=value1,KEY2=value2"
 
 **VLLM Backend:**
 - `LLAMACTL_VLLM_COMMAND` - VLLM executable command

--- a/webui/src/contexts/AuthContext.tsx
+++ b/webui/src/contexts/AuthContext.tsx
@@ -1,4 +1,5 @@
-import { type ReactNode, createContext, useContext, useState, useEffect, useCallback } from 'react'
+import { API_BASE } from '@/lib/api'
+import { type ReactNode, createContext, useCallback, useContext, useEffect, useState } from 'react'
 
 interface AuthContextState {
   isAuthenticated: boolean
@@ -62,7 +63,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   // Validate API key by making a test request
   const validateApiKey = async (key: string): Promise<boolean> => {
     try {
-      const response = await fetch('/api/v1/instances', {
+      const response = await fetch(API_BASE + '/instances', {
         headers: {
           'Authorization': `Bearer ${key}`,
           'Content-Type': 'application/json'

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -1,7 +1,10 @@
 import type { CreateInstanceOptions, Instance } from "@/types/instance";
 import { handleApiError } from "./errorUtils";
 
-const API_BASE = "/api/v1";
+// Adding baseURI as a prefix to support being served behind a subpath
+// e.g. when llmamctl's `/` is served behind a reverse proxy at `/proxy/...`
+// the baseURI will be `/proxy/` and the API calls will be made to `/proxy/api/v1/<endpoint>`
+export const API_BASE = document.baseURI + "api/v1";
 
 // Base API call function with error handling
 async function apiCall<T>(

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -21,4 +21,6 @@ export default defineConfig({
     setupFiles: ['./src/test/setup.ts'],
     css: true,
   },
+  // ensures relative asset paths to support being served behind a subpath
+  base: "./"
 })


### PR DESCRIPTION
Added support for serving behind a reverse proxy.

In certain deployments, llamactl can be served behind a proxy server like NGINX. A request will have to travel to `https://example.com/some/route/to/llamactl/<endpoint>` which will be forwarded to `llamactl/<endpoint>`

This pull request fixes two issues:
1. Web clients were using absolute paths and thus send requests to the incorrect route.
2. Some reverse proxy like NGINX may decide to buffer streaming via server-sent events. The server (llamactl) must set the response header `X-Accel-Buffering=no` to disable this behavior.

Changes:
- Added support for specifying response headers for each backend
  - Allowing users to set `X-Accel-Buffering: no` to disable buffering for streaming responses in nginx
  - Updated `configuration.md` to document the new configuration options
- Modified Vite config to build with `base: "./"`, making assets be accessed via relative paths
- Updated API_BASE to use `document.baseURI`, allowing API calls to be made relative to the base path

Comments:
I tried to make the changes as minimal as possible and thus did not add setting the response headers at the global level since `Process` does not have a reference to `ServerConfig`. And I think that adding another reference was too much.