### PR TITLE
feat: Added support for configuring access-control-request-headers for CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ server:
   host: "0.0.0.0"                # Server host to bind to
   port: 8080                     # Server port to bind to
   allowed_origins: ["*"]         # Allowed CORS origins (default: all)
+  allowed_headers: ["*"]         # Allowed CORS headers (default: all)
   enable_swagger: false          # Enable Swagger UI for API docs
 
 backends:

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -17,6 +17,7 @@ server:
   host: "0.0.0.0"                # Server host to bind to
   port: 8080                     # Server port to bind to
   allowed_origins: ["*"]         # Allowed CORS origins (default: all)
+  allowed_headers: ["*"]         # Allowed CORS headers (default: all)
   enable_swagger: false          # Enable Swagger UI for API docs
 
 backends:
@@ -104,6 +105,7 @@ server:
   host: "0.0.0.0"         # Server host to bind to (default: "0.0.0.0")
   port: 8080              # Server port to bind to (default: 8080)
   allowed_origins: ["*"]  # CORS allowed origins (default: ["*"])
+  allowed_headers: ["*"]  # CORS allowed headers (default: ["*"])
   enable_swagger: false   # Enable Swagger UI (default: false)
 ```
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,6 +57,9 @@ type ServerConfig struct {
 	// Allowed origins for CORS (e.g., "http://localhost:3000")
 	AllowedOrigins []string `yaml:"allowed_origins"`
 
+	// Allowed headers for CORS (e.g., "Accept", "Authorization", "Content-Type", "X-CSRF-Token")
+	AllowedHeaders []string `yaml:"allowed_headers"`
+
 	// Enable Swagger UI for API documentation
 	EnableSwagger bool `yaml:"enable_swagger"`
 
@@ -136,6 +139,7 @@ func LoadConfig(configPath string) (AppConfig, error) {
 			Host:           "0.0.0.0",
 			Port:           8080,
 			AllowedOrigins: []string{"*"}, // Default to allow all origins
+			AllowedHeaders: []string{"*"}, // Default to allow all headers
 			EnableSwagger:  false,
 		},
 		Backends: BackendConfig{

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -20,7 +20,7 @@ func SetupRouter(handler *Handler) *chi.Mux {
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   handler.cfg.Server.AllowedOrigins,
 		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
+		AllowedHeaders:   handler.cfg.Server.AllowedHeaders,
 		ExposedHeaders:   []string{"Link"},
 		AllowCredentials: false,
 		MaxAge:           300,


### PR DESCRIPTION
This PR allows server configuration file (llamactl.yaml) to pass through `AllowedHeaders` to the CORS middleware. And change the default `AllowedHeaders` to "*".

## Context

llamactl has hardcoded allowed CORS headers. Certain web clients will refuse to send POST requests to the server if not all of the requested headers are allowed.

For example, the client may request "http-referer", "x-title", and be denied the "access-control-*" headers.

```shell
$ curl -i -X OPTIONS 'https://your-domain.com/route/to/llamactl/v1/chat/completions' \
  -H 'authority: your-domain.com' \
  -H 'accept: */*' \
  -H 'accept-encoding: gzip, deflate, br, zstd' \
  -H 'accept-language: en-US,en;q=0.9,th;q=0.8' \
  -H 'access-control-request-headers: authorization,content-type,http-referer,x-title' \
  -H 'access-control-request-method: POST' \
  -H 'cache-control: no-cache' \
  -H 'origin: https://other-domain.com' \
  -H 'pragma: no-cache' \
  -H 'priority: u=1, i' \
  -H 'sec-fetch-dest: empty' \
  -H 'sec-fetch-mode: cors' \
  -H 'sec-fetch-site: cross-site' \
  -H 'user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36 Edg/140.0.0.0'
HTTP/2 200 
server: nginx/1.27.5
date: Sat, 04 Oct 2025 08:05:58 GMT
content-length: 0
vary: Origin
vary: Access-Control-Request-Method
vary: Access-Control-Request-Headers
```

I changed the default to allow all methods, mirroring llama.cpp's llama-server, which allows all headers by default.
> `res.set_header("Access-Control-Allow-Headers",     "*");`
> https://github.com/ggml-org/llama.cpp/blob/128d522c04286e019666bd6ee4d18e3fbf8772e2/tools/server/server.cpp#L4246

## After the change

```shell
$ curl -i -X OPTIONS 'https://your-domain.com/route/to/llamactl/v1/chat/completions' \
  -H 'authority: your-domain.com' \
  -H 'accept: */*' \
  -H 'accept-encoding: gzip, deflate, br, zstd' \
  -H 'accept-language: en-US,en;q=0.9,th;q=0.8' \
  -H 'access-control-request-headers: authorization,content-type,http-referer,x-title' \
  -H 'access-control-request-method: POST' \
  -H 'cache-control: no-cache' \
  -H 'origin: https://other-domain.com' \
  -H 'pragma: no-cache' \
  -H 'priority: u=1, i' \
  -H 'sec-fetch-dest: empty' \
  -H 'sec-fetch-mode: cors' \
  -H 'sec-fetch-site: cross-site' \
  -H 'user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36 Edg/140.0.0.0'
HTTP/2 200 
server: nginx/1.27.5
date: Sat, 04 Oct 2025 08:52:24 GMT
content-length: 0
access-control-allow-headers: Authorization, Content-Type, Http-Referer, X-Title
access-control-allow-methods: POST
access-control-allow-origin: *
access-control-max-age: 300
vary: Origin
vary: Access-Control-Request-Method
vary: Access-Control-Request-Headers
```