### PR TITLE
docs: add macOS LaunchAgent deployment guide

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,235 @@
+# Deployment
+
+This guide covers running llamactl as a long-running service on supported platforms.
+For interactive use, simply running `llamactl --config /path/to/config.yaml`
+in a terminal is enough. For background operation that survives reboots and
+auto-restarts on crash, use a platform-native service manager.
+
+## macOS LaunchAgent
+
+LaunchAgent is the native macOS mechanism for user-scoped background services.
+It starts llamactl at login, restarts it on crash, and integrates with
+the standard `launchctl` tooling.
+
+### Prerequisites
+
+- llamactl installed and on `PATH` (see [Installation](installation.md))
+- Backend(s) installed and configured in your `config.yaml`
+  (see [Configuration](configuration.md))
+- Verify that `llamactl --config /path/to/config.yaml` starts the server
+  successfully in foreground before installing the LaunchAgent — this isolates
+  config issues from service issues.
+
+### Plist template
+
+Create the file `~/Library/LaunchAgents/com.example.llamactl.plist` with the
+following content. Replace placeholders (`<...>`) with absolute paths
+on your machine.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.example.llamactl</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/llamactl</string>
+        <string>--config</string>
+        <string>/Users/&lt;USERNAME&gt;/.config/llamactl/config.yaml</string>
+    </array>
+
+    <!-- PATH must include any backend binaries (e.g. mlx_lm.server when MLX
+         is installed in a Python venv). Adjust to match your setup. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/&lt;USERNAME&gt;/.venvs/mlx-llm/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/&lt;USERNAME&gt;</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Always restart, regardless of exit reason. Combined with
+         ThrottleInterval, this gives the daemon resilience without
+         tight crash loops. -->
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/&lt;USERNAME&gt;/Library/Logs/llamactl/llamactl.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/&lt;USERNAME&gt;/Library/Logs/llamactl/llamactl.err.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>
+```
+
+!!! warning "Absolute paths required"
+    LaunchAgent plists do not expand `~`, `$HOME`, or other shell variables.
+    Every path in the plist must be absolute. Replace `<USERNAME>` with the
+    output of `echo $USER`.
+
+!!! tip "PATH for MLX users"
+    If your MLX backend is installed in a Python venv (the common pattern on
+    Apple Silicon), the venv `bin` directory must be in `EnvironmentVariables.PATH`
+    so that llamactl can find `mlx_lm.server`. Alternatively, set the full path
+    to the executable directly in `backends.mlx.command` in your `config.yaml`.
+
+### Installation
+
+```bash
+# Ensure the log directory exists (StandardOutPath/StandardErrorPath will fail otherwise)
+mkdir -p ~/Library/Logs/llamactl
+
+# Load the LaunchAgent
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.example.llamactl.plist
+
+# Verify it is running
+launchctl print "gui/$(id -u)/com.example.llamactl" | head -20
+```
+
+The output of `launchctl print` should show `state = running` and a non-zero
+`pid`. The HTTP endpoint should respond at the address configured in your
+`config.yaml` (default: `http://127.0.0.1:8080`).
+
+### Inspection and debugging
+
+```bash
+# Combined status (state, pid, last exit code, keepalive)
+launchctl print "gui/$(id -u)/com.example.llamactl"
+
+# Tail logs in real time
+tail -F ~/Library/Logs/llamactl/llamactl.log ~/Library/Logs/llamactl/llamactl.err.log
+
+# Check that the HTTP endpoint responds
+curl -s http://127.0.0.1:8080/v1/models | python3 -m json.tool
+```
+
+### Updating the plist
+
+If you edit the plist after installation, you must reload it for the changes
+to take effect. launchd caches the plist contents in memory at `bootstrap`
+time, so editing the file alone does not propagate.
+
+```bash
+launchctl bootout "gui/$(id -u)/com.example.llamactl"
+sleep 2
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.example.llamactl.plist
+```
+
+!!! note "Why both bootout and bootstrap?"
+    `launchctl reload` was deprecated in macOS Catalina. The modern equivalent
+    is the explicit `bootout` then `bootstrap` sequence shown above. The brief
+    `sleep 2` gives launchd time to fully release the previous instance.
+
+### Stopping and uninstalling
+
+```bash
+# Stop the service without uninstalling (will not auto-restart)
+launchctl bootout "gui/$(id -u)/com.example.llamactl"
+
+# Full uninstall
+launchctl bootout "gui/$(id -u)/com.example.llamactl"
+rm ~/Library/LaunchAgents/com.example.llamactl.plist
+
+# Optional: remove the log directory
+rm -rf ~/Library/Logs/llamactl
+```
+
+!!! warning "Killing the process directly is not enough"
+    With `KeepAlive=true`, killing the llamactl process via `kill <pid>` will
+    cause launchd to immediately restart it. To stop the service, use
+    `launchctl bootout`.
+
+### Common issues
+
+**`Could not find service in domain for user: 501`**
+
+You queried the wrong service identifier. The domain is `gui/$(id -u)` (the
+current user's GUI session). The service label must match the `Label` field
+in the plist exactly.
+
+**Port already in use on startup (`address already in use`)**
+
+Another process is already bound to the port configured in `config.yaml`.
+Find and stop the offending process:
+
+```bash
+lsof -nP -iTCP:8080 -sTCP:LISTEN
+# Then kill the listed PID, or change `server.port` in config.yaml
+```
+
+**Crash loop visible in `proxy.err.log`**
+
+A misconfiguration in either the plist or `config.yaml` is causing llamactl
+to exit at startup. `ThrottleInterval=10` prevents this from saturating the
+system, but it will keep retrying every 10 seconds. Tail the error log to
+see the actual exit reason:
+
+```bash
+tail -50 ~/Library/Logs/llamactl/llamactl.err.log
+```
+
+Common culprits: wrong path to `--config`, missing backend binary on `PATH`,
+permission issues on `data_dir`.
+
+## Linux systemd
+
+A user-level systemd unit is the equivalent of a LaunchAgent on Linux. The
+basic shape is:
+
+```ini
+# ~/.config/systemd/user/llamactl.service
+[Unit]
+Description=llamactl - local LLM management
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/llamactl --config %h/.config/llamactl/config.yaml
+Restart=on-failure
+RestartSec=10s
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+
+[Install]
+WantedBy=default.target
+```
+
+Install with:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now llamactl.service
+systemctl --user status llamactl.service
+journalctl --user -u llamactl -f
+```
+
+> A complete systemd guide (including caveats for backends like vLLM that
+> need GPU access) is welcome via [pull request](https://github.com/lordmathis/llamactl/blob/main/CONTRIBUTING.md).
+
+## Verifying the service is healthy
+
+Regardless of platform, llamactl exposes the same OpenAI-compatible probe:
+
+```bash
+# Unauthenticated probe (works if require_inference_auth=false)
+curl -s http://127.0.0.1:8080/v1/models | python3 -m json.tool
+
+# With auth enabled
+curl -s -H "Authorization: Bearer <your-inference-key>" \
+    http://127.0.0.1:8080/v1/models | python3 -m json.tool
+```
+
+For instance-level diagnostics, see [Troubleshooting](troubleshooting.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
   - Installation: installation.md
   - Quick Start: quick-start.md
   - Configuration: configuration.md
+  - Deployment: deployment.md
   - Managing Instances: managing-instances.md
   - Managing Models: managing-models.md
   - API Reference: api-reference.md


### PR DESCRIPTION
## Summary

Adds a new `Deployment` page (`docs/deployment.md`) that documents how to run llamactl as a long-running service. The current docs cover install methods (binary, Docker, source) and configuration in depth, but daemonization is not addressed — users who want a proper service have to reverse-engineer it.

## What's added

- **macOS LaunchAgent**: plist template, `launchctl bootstrap`/`bootout` commands, debug recipes, update procedure, and troubleshooting (port conflicts, signal handling, KeepAlive crash loops).
- **Linux systemd**: minimal stub showing a working user-level `.service` unit, explicitly inviting community contributions for production-grade guidance (GPU backends, etc.).
- **Verifying the service is healthy**: platform-agnostic OpenAI probe.

The new page is wired into `mkdocs.yml` navigation between `Configuration` and `Managing Instances`.

## Why I'm submitting this

I just deployed llamactl on Apple Silicon with the MLX backend and rebuilt the LaunchAgent setup from scratch. Notable details captured from real-world experience:

- `KeepAlive` set as a simple boolean `<true/>` rather than a conditional dict — kills via `kill <pid>` are correctly auto-restarted with this form.
- Modern bootstrap/bootout commands (the legacy `launchctl reload` was deprecated in Catalina).
- PATH gotcha for MLX users: when MLX is installed in a Python venv (the common pattern on Apple Silicon), the venv `bin` must be in `EnvironmentVariables.PATH` so `mlx_lm.server` is found.

## Validation

The macOS LaunchAgent section was validated empirically using a parallel `com.example.llamactl-test` service following the doc step by step. All commands behaved as documented:

- ✅ `launchctl bootstrap` brings the service up, `launchctl print` shows `state = running`
- ✅ HTTP probe returns 200 with empty model list
- ✅ `KeepAlive` restarts the process with a new PID after manual `kill <pid>`
- ✅ Reload cycle (`bootout` → `bootstrap`) yields a fresh PID
- ✅ Full uninstall returns the expected "Could not find service" error

Additionally:
- `mkdocs build --strict` passes (pre-existing OpenAPI warnings unrelated to this change)
- All internal links resolve (`Installation`, `Configuration`, `Troubleshooting`)
- Plist template lints clean with `plutil`
- Anonymized throughout: only `<USERNAME>` and `com.example.llamactl` placeholders

## Not in scope (intentional)

- **Linux systemd** is a minimal stub. I haven't run llamactl on Linux, so I wrote a starting point rather than fake the depth. Open call for someone with actual systemd + GPU backend experience to expand it in a follow-up.
- **Windows**: no section yet — the release ships Windows binaries but I don't have a Windows machine to test `nssm` or Windows Service patterns.

Happy to revise structure, split into smaller PRs, or rephrase anything if it conflicts with your vision for the docs.
