### PR TITLE
feat: improve instance creation clarity and live model status

### DIFF
--- a/webui/src/components/BackendFormField.tsx
+++ b/webui/src/components/BackendFormField.tsx
@@ -4,10 +4,28 @@ import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
-import { FileCode } from 'lucide-react'
+import { FileCode, HelpCircle } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { getBackendFieldType, basicBackendFieldsConfig } from '@/lib/zodFormUtils'
 import ExtraArgsInput from '@/components/form/ExtraArgsInput'
 import type { CreateInstanceOptions } from '@/schemas/instanceOptions'
+
+/** Renders a label with an optional tooltip help icon. */
+const FieldLabel: React.FC<{ htmlFor: string; label: string; tooltip?: string }> = ({ htmlFor, label, tooltip }) => (
+  <div className="flex items-center gap-1.5">
+    <Label htmlFor={htmlFor}>{label}</Label>
+    {tooltip && (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <HelpCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
+          </TooltipTrigger>
+          <TooltipContent className="max-w-xs text-xs leading-relaxed">{tooltip}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    )}
+  </div>
+)
 
 interface BackendFormFieldProps {
   fieldKey: string
@@ -78,7 +96,7 @@ const BackendFormField: React.FC<BackendFormFieldProps> = ({ fieldKey, value, on
   }
 
   // Get configuration for basic fields, or use field name for advanced fields
-  const config = basicBackendFieldsConfig[fieldKey] || { label: fieldKey }
+  const config = basicBackendFieldsConfig[fieldKey] || { label: fieldKey, tooltip: undefined }
 
   // Get type from Zod schema
   const fieldType = getBackendFieldType(fieldKey)
@@ -97,21 +115,31 @@ const BackendFormField: React.FC<BackendFormFieldProps> = ({ fieldKey, value, on
               checked={typeof value === 'boolean' ? value : false}
               onCheckedChange={(checked) => handleChange(checked)}
             />
-            <Label htmlFor={fieldKey} className="text-sm font-normal">
-              {config.label}
-              {config.description && (
-                <span className="text-muted-foreground ml-1">- {config.description}</span>
+            <div className="flex items-center gap-1.5">
+              <Label htmlFor={fieldKey} className="text-sm font-normal">
+                {config.label}
+                {config.description && (
+                  <span className="text-muted-foreground ml-1">- {config.description}</span>
+                )}
+              </Label>
+              {'tooltip' in config && config.tooltip && (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <HelpCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-xs text-xs leading-relaxed">{config.tooltip}</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
               )}
-            </Label>
+            </div>
           </div>
         )
 
       case 'number':
         return (
           <div className="grid gap-2">
-            <Label htmlFor={fieldKey}>
-              {config.label}
-            </Label>
+            <FieldLabel htmlFor={fieldKey} label={config.label} tooltip={'tooltip' in config ? config.tooltip : undefined} />
             <Input
               id={fieldKey}
               type="number"
@@ -135,9 +163,7 @@ const BackendFormField: React.FC<BackendFormFieldProps> = ({ fieldKey, value, on
       case 'array':
         return (
           <div className="grid gap-2">
-            <Label htmlFor={fieldKey}>
-              {config.label}
-            </Label>
+            <FieldLabel htmlFor={fieldKey} label={config.label} tooltip={'tooltip' in config ? config.tooltip : undefined} />
             <Input
               id={fieldKey}
               type="text"
@@ -161,9 +187,7 @@ const BackendFormField: React.FC<BackendFormFieldProps> = ({ fieldKey, value, on
       default:
         return (
           <div className="grid gap-2">
-            <Label htmlFor={fieldKey}>
-              {config.label}
-            </Label>
+            <FieldLabel htmlFor={fieldKey} label={config.label} tooltip={'tooltip' in config ? config.tooltip : undefined} />
             <Input
               id={fieldKey}
               type="text"

--- a/webui/src/components/InstanceCard.tsx
+++ b/webui/src/components/InstanceCard.tsx
@@ -8,9 +8,11 @@ import LogsDialog from "@/components/LogDialog";
 import ModelsDialog from "@/components/ModelsDialog";
 import HealthBadge from "@/components/HealthBadge";
 import BackendBadge from "@/components/BackendBadge";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useInstanceHealth } from "@/hooks/useInstanceHealth";
 import { instancesApi, llamaCppApi, type Model } from "@/lib/api";
+
+const MODELS_POLL_INTERVAL = 10_000; // 10 seconds
 
 interface InstanceCardProps {
   instance: Instance;
@@ -32,30 +34,57 @@ function InstanceCard({
   const [showAllActions, setShowAllActions] = useState(false);
   const [models, setModels] = useState<Model[]>([]);
   const health = useInstanceHealth(instance.name, instance.status);
+  const pollIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   const running = instance.status === "running";
   const isLlamaCpp = instance.options?.backend_type === "llama_cpp";
 
   // Fetch models for llama.cpp instances
-  useEffect(() => {
+  const fetchModels = useCallback(async () => {
     if (!isLlamaCpp || !running) {
       setModels([]);
       return;
     }
-
-    void (async () => {
-      try {
-        const fetchedModels = await llamaCppApi.getModels(instance.name);
-        setModels(fetchedModels);
-      } catch {
-        setModels([]);
-      }
-    })();
+    try {
+      const fetchedModels = await llamaCppApi.getModels(instance.name);
+      setModels(fetchedModels);
+    } catch {
+      setModels([]);
+    }
   }, [instance.name, isLlamaCpp, running]);
+
+  // Poll model state while running so the badge stays current
+  useEffect(() => {
+    void fetchModels();
+
+    if (isLlamaCpp && running) {
+      pollIntervalRef.current = setInterval(() => {
+        void fetchModels();
+      }, MODELS_POLL_INTERVAL);
+    }
+
+    return () => {
+      if (pollIntervalRef.current) {
+        clearInterval(pollIntervalRef.current);
+        pollIntervalRef.current = null;
+      }
+    };
+  }, [fetchModels, isLlamaCpp, running]);
+
+  // Callback passed to ModelsDialog so a load/unload immediately refreshes the card
+  const handleModelsChange = useCallback(() => {
+    void fetchModels();
+  }, [fetchModels]);
 
   // Calculate model counts
   const totalModels = models.length;
   const loadedModels = models.filter(m => m.status?.value === "loaded").length;
+
+  // For single-model instances show the model id/alias directly
+  const singleLoadedModel =
+    isLlamaCpp && running && totalModels === 1 && loadedModels === 1
+      ? models[0].id
+      : null;
 
   const handleStart = () => {
     startInstance(instance.name);
@@ -133,6 +162,11 @@ function InstanceCard({
                 <Badge variant="outline" className="text-xs">
                   <Layers className="h-3 w-3 mr-1" />
                   {instance.options.group}
+                </Badge>
+              )}
+              {isLlamaCpp && running && singleLoadedModel && (
+                <Badge variant="secondary" className="text-xs max-w-[14rem] truncate" title={singleLoadedModel}>
+                  {singleLoadedModel}
                 </Badge>
               )}
               {isLlamaCpp && running && totalModels > 1 && (
@@ -264,9 +298,14 @@ function InstanceCard({
 
       <ModelsDialog
         open={isModelsOpen}
-        onOpenChange={setIsModelsOpen}
+        onOpenChange={(open) => {
+          setIsModelsOpen(open);
+          // Refresh card badge immediately when dialog closes
+          if (!open) handleModelsChange();
+        }}
         instanceName={instance.name}
         isRunning={running}
+        onModelsChange={handleModelsChange}
       />
     </>
   );

--- a/webui/src/components/ModelsDialog.tsx
+++ b/webui/src/components/ModelsDialog.tsx
@@ -24,6 +24,8 @@ interface ModelsDialogProps {
   onOpenChange: (open: boolean) => void
   instanceName: string
   isRunning: boolean
+  /** Called after a model is loaded or unloaded so parent components can refresh. */
+  onModelsChange?: () => void
 }
 
 interface Model {
@@ -65,6 +67,7 @@ const ModelsDialog: React.FC<ModelsDialogProps> = ({
   onOpenChange,
   instanceName,
   isRunning,
+  onModelsChange,
 }) => {
   const [models, setModels] = useState<Model[]>([])
   const [loading, setLoading] = useState(false)
@@ -124,6 +127,7 @@ const ModelsDialog: React.FC<ModelsDialogProps> = ({
       await new Promise(resolve => setTimeout(resolve, 500))
       // Refresh models list after loading
       await fetchModels()
+      onModelsChange?.()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load model')
     } finally {
@@ -146,6 +150,7 @@ const ModelsDialog: React.FC<ModelsDialogProps> = ({
       await new Promise(resolve => setTimeout(resolve, 500))
       // Refresh models list after unloading
       await fetchModels()
+      onModelsChange?.()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to unload model')
     } finally {

--- a/webui/src/components/__tests__/InstanceCard.test.tsx
+++ b/webui/src/components/__tests__/InstanceCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import InstanceCard from '@/components/InstanceCard'
 import { type Instance, BackendType } from '@/types/instance'
@@ -12,6 +12,17 @@ vi.mock('@/hooks/useInstanceHealth', () => ({
     lastChecked: new Date(),
     source: 'http'
   }))
+}))
+
+// Mock the API so model fetches are controllable
+vi.mock('@/lib/api', () => ({
+  instancesApi: {
+    get: vi.fn(),
+    getHealth: vi.fn(() => Promise.resolve()),
+  },
+  llamaCppApi: {
+    getModels: vi.fn(() => Promise.resolve([])),
+  },
 }))
 
 describe('InstanceCard - Instance Actions and State', () => {
@@ -338,6 +349,111 @@ afterEach(() => {
 
       // Modal should close
       expect(screen.queryByText('Logs: running-instance')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Model Status Badge', () => {
+    it('shows loaded model name badge for a single-model running llama.cpp instance', async () => {
+      const { llamaCppApi } = await import('@/lib/api')
+      vi.mocked(llamaCppApi.getModels).mockResolvedValue([
+        {
+          id: 'ggml-org/gemma-3-1b-it-GGUF:Q4_K_M',
+          object: 'model',
+          owned_by: 'llamacpp',
+          created: 0,
+          in_cache: true,
+          path: '/path/to/model.gguf',
+          status: { value: 'loaded', args: [] },
+        },
+      ])
+
+      render(
+        <InstanceCard
+          instance={runningInstance}
+          startInstance={mockStartInstance}
+          stopInstance={mockStopInstance}
+          deleteInstance={mockDeleteInstance}
+          editInstance={mockEditInstance}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTitle('ggml-org/gemma-3-1b-it-GGUF:Q4_K_M')).toBeInTheDocument()
+      })
+    })
+
+    it('shows X/N models badge for multi-model running instances', async () => {
+      const { llamaCppApi } = await import('@/lib/api')
+      vi.mocked(llamaCppApi.getModels).mockResolvedValue([
+        { id: 'model-a', object: 'model', owned_by: 'llamacpp', created: 0, in_cache: true, path: '', status: { value: 'loaded', args: [] } },
+        { id: 'model-b', object: 'model', owned_by: 'llamacpp', created: 0, in_cache: true, path: '', status: { value: 'unloaded', args: [] } },
+        { id: 'model-c', object: 'model', owned_by: 'llamacpp', created: 0, in_cache: true, path: '', status: { value: 'unloaded', args: [] } },
+      ])
+
+      render(
+        <InstanceCard
+          instance={runningInstance}
+          startInstance={mockStartInstance}
+          stopInstance={mockStopInstance}
+          deleteInstance={mockDeleteInstance}
+          editInstance={mockEditInstance}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('1/3 models')).toBeInTheDocument()
+      })
+    })
+
+    it('does not show model badge for stopped instances', async () => {
+      const { llamaCppApi } = await import('@/lib/api')
+      vi.mocked(llamaCppApi.getModels).mockResolvedValue([
+        { id: 'some-model', object: 'model', owned_by: 'llamacpp', created: 0, in_cache: true, path: '', status: { value: 'loaded', args: [] } },
+      ])
+
+      render(
+        <InstanceCard
+          instance={stoppedInstance}
+          startInstance={mockStartInstance}
+          stopInstance={mockStopInstance}
+          deleteInstance={mockDeleteInstance}
+          editInstance={mockEditInstance}
+        />
+      )
+
+      // Model fetch should not be called for stopped instances
+      expect(llamaCppApi.getModels).not.toHaveBeenCalled()
+      expect(screen.queryByTitle('some-model')).not.toBeInTheDocument()
+    })
+
+    it('sets up polling interval for running llama.cpp instances', async () => {
+      vi.useFakeTimers()
+      const { llamaCppApi } = await import('@/lib/api')
+      vi.mocked(llamaCppApi.getModels).mockResolvedValue([])
+
+      const { unmount } = render(
+        <InstanceCard
+          instance={runningInstance}
+          startInstance={mockStartInstance}
+          stopInstance={mockStopInstance}
+          deleteInstance={mockDeleteInstance}
+          editInstance={mockEditInstance}
+        />
+      )
+
+      // Let the initial render and async fetch settle
+      await act(async () => { await Promise.resolve() })
+      expect(llamaCppApi.getModels).toHaveBeenCalledTimes(1)
+
+      // Advance past the 10 s polling interval
+      await act(async () => {
+        vi.advanceTimersByTime(10_000)
+        await Promise.resolve()
+      })
+      expect(llamaCppApi.getModels).toHaveBeenCalledTimes(2)
+
+      unmount()
+      vi.useRealTimers()
     })
   })
 

--- a/webui/src/components/__tests__/InstanceModal.test.tsx
+++ b/webui/src/components/__tests__/InstanceModal.test.tsx
@@ -202,6 +202,58 @@ describe('InstanceModal - Form Logic and Validation', () => {
     })
   })
 
+  describe('Router Mode Callout', () => {
+    it('shows router mode callout on Backend tab when no model fields are set', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <InstanceDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+          onSave={mockOnSave}
+        />
+      )
+
+      const backendTab = screen.getByRole('tab', { name: /Backend/i })
+      await user.click(backendTab)
+
+      expect(
+        screen.getByText(/No model specified.*router mode will be used/i)
+      ).toBeInTheDocument()
+    })
+
+    it('does not show router mode callout when editing an instance that has a model set', async () => {
+      const user = userEvent.setup()
+
+      const instanceWithModel = {
+        id: 5,
+        name: 'model-instance',
+        status: 'stopped' as const,
+        options: {
+          backend_type: 'llama_cpp' as const,
+          backend_options: { model: '/models/gemma.gguf' },
+        },
+      }
+
+      render(
+        <InstanceDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+          onSave={mockOnSave}
+          instance={instanceWithModel}
+        />
+      )
+
+      const backendTab = screen.getByRole('tab', { name: /Backend/i })
+      await user.click(backendTab)
+
+      // Callout should NOT appear when a model is already configured
+      expect(
+        screen.queryByText(/No model specified.*router mode will be used/i)
+      ).not.toBeInTheDocument()
+    })
+  })
+
   describe('Auto Restart Configuration', () => {
     it('shows and hides restart options based on auto restart checkbox', async () => {
       const user = userEvent.setup()

--- a/webui/src/components/instance/BackendTab.tsx
+++ b/webui/src/components/instance/BackendTab.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { BackendType, type CreateInstanceOptions } from '@/types/instance'
 import { Button } from '@/components/ui/button'
-import { Terminal, ChevronDown, ChevronRight } from 'lucide-react'
+import { Terminal, ChevronDown, ChevronRight, Info } from 'lucide-react'
 import { getBasicBackendFields } from '@/lib/zodFormUtils'
 import BackendFormField from '@/components/BackendFormField'
 import SelectInput from '@/components/form/SelectInput'
@@ -29,6 +29,14 @@ const BackendTab: React.FC<BackendTabProps> = ({
   const backendSettings = useBackendSettings(formData.backend_type)
   const basicBackendFields = getBasicBackendFields(formData.backend_type)
 
+  // Show router-mode callout for llama.cpp when no explicit model is configured
+  const llamaCppOptions = formData.backend_options as Record<string, unknown> | undefined
+  const showRouterModeCallout =
+    formData.backend_type === BackendType.LLAMA_CPP &&
+    !llamaCppOptions?.model &&
+    !llamaCppOptions?.hf_repo &&
+    !formData.preset_ini?.trim()
+
   const getCommandPlaceholder = () => {
     if (backendSettings?.command) {
       return backendSettings.command
@@ -48,6 +56,29 @@ const BackendTab: React.FC<BackendTabProps> = ({
 
   return (
     <div className="space-y-6 py-4">
+      {showRouterModeCallout && (
+        <div className="flex gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950">
+          <Info className="h-5 w-5 shrink-0 text-blue-500 mt-0.5" />
+          <div className="space-y-1 text-sm">
+            <p className="font-medium text-blue-800 dark:text-blue-200">No model specified — router mode will be used</p>
+            <p className="text-blue-700 dark:text-blue-300">
+              Without a model, llama-server starts in <strong>router mode</strong> and
+              auto-discovers any model presets cached in your Hugging Face cache directory.
+              This is how multi-model instances work, but it can be surprising if you intended
+              to load a single model.
+            </p>
+            <p className="text-blue-700 dark:text-blue-300">
+              To load a specific model, set one of:
+            </p>
+            <ul className="list-disc list-inside text-blue-700 dark:text-blue-300 space-y-0.5">
+              <li><strong>Model Path</strong> — local <code>.gguf</code> file (e.g. <code>/models/gemma-3-1b.gguf</code>)</li>
+              <li><strong>HF Repo</strong> + <strong>HF File</strong> — download from Hugging Face on first start</li>
+              <li><strong>Preset tab</strong> — define a <code>preset.ini</code> to intentionally configure multiple models for router mode</li>
+            </ul>
+          </div>
+        </div>
+      )}
+
       <SelectInput
         id="backend_type"
         label="Backend Type"

--- a/webui/src/components/instance/GeneralTab.tsx
+++ b/webui/src/components/instance/GeneralTab.tsx
@@ -83,7 +83,7 @@ const GeneralTab: React.FC<GeneralTabProps> = ({
         />
         {nameError && <p className="text-sm text-red-500">{nameError}</p>}
         <p className="text-sm text-muted-foreground">
-          Unique identifier for the instance
+          A short, unique name for this instance (letters, numbers, hyphens). Cannot be changed after creation.
         </p>
       </div>
 
@@ -112,7 +112,8 @@ const GeneralTab: React.FC<GeneralTabProps> = ({
           placeholder="e.g., large-models"
         />
         <p className="text-sm text-muted-foreground">
-          Optional group for managing instance quotas and hierarchical eviction
+          Optional label for grouping instances (e.g. <code>large-models</code>). Groups can have
+          shared running-instance limits configured in the server config under <code>instances.group_limits</code>.
         </p>
       </div>
 
@@ -125,7 +126,7 @@ const GeneralTab: React.FC<GeneralTabProps> = ({
           value={formData.idle_timeout}
           onChange={(value) => onChange("idle_timeout", value)}
           placeholder="30"
-          description="Minutes before stopping an idle instance"
+          description="Minutes of inactivity before the instance is automatically stopped to free resources (0 = never stop automatically)."
         />
 
         <CheckboxInput
@@ -133,7 +134,7 @@ const GeneralTab: React.FC<GeneralTabProps> = ({
           label="On Demand Start"
           value={formData.on_demand_start}
           onChange={(value) => onChange("on_demand_start", value)}
-          description="Start instance only when needed"
+          description="When enabled, llamactl starts this instance automatically the first time a request arrives for it, instead of requiring a manual start."
         />
       </div>
 

--- a/webui/src/lib/zodFormUtils.ts
+++ b/webui/src/lib/zodFormUtils.ts
@@ -18,26 +18,57 @@ const basicLlamaCppFieldsConfig: Record<string, {
   label: string
   description?: string
   placeholder?: string
+  tooltip?: string
 }> = {
   model: {
     label: 'Model Path',
-    placeholder: '/path/to/model.gguf',
-    description: 'Path to the model file'
+    placeholder: '/models/gemma-3-1b-it-Q4_K_M.gguf',
+    description: 'Local path to a .gguf model file. Leave empty to use HF Repo/File or router mode.',
+    tooltip:
+      'Absolute path to a locally stored GGUF model file. ' +
+      'If you leave this empty and also leave HF Repo empty, llama-server starts in router mode ' +
+      'and may auto-load any model presets found in your Hugging Face cache. ' +
+      'Use the Preset tab to define router-mode models intentionally.'
   },
   hf_repo: {
-    label: 'Hugging Face Repository',
-    placeholder: 'microsoft/DialoGPT-medium',
-    description: 'Hugging Face model repository'
+    label: 'HF Repo',
+    placeholder: 'ggml-org/gemma-3-1b-it-GGUF',
+    description: 'Hugging Face repository to download a GGUF model from (e.g. ggml-org/gemma-3-1b-it-GGUF).',
+    tooltip:
+      'The Hugging Face repository ID in the form owner/repo-name. ' +
+      'Must point to a repository that contains .gguf quantised model files. ' +
+      'Combine with HF File to select a specific quantisation; if HF File is empty llama-server ' +
+      'picks the first suitable file automatically.'
+  },
+  hf_file: {
+    label: 'HF File',
+    placeholder: 'gemma-3-1b-it-Q4_K_M.gguf',
+    description: 'Specific .gguf filename inside the HF Repo (leave empty for auto-select).',
+    tooltip:
+      'The filename of the quantised model within the Hugging Face repository. ' +
+      'For example gemma-3-1b-it-Q4_K_M.gguf. ' +
+      'If left empty, llama-server selects the first .gguf file it finds in the repository, ' +
+      'which may not be the quantisation level you want.'
   },
   gpu_layers: {
     label: 'GPU Layers',
     placeholder: '0',
-    description: 'Number of layers to offload to GPU'
+    description: 'Layers to offload to GPU. Use -1 for all layers (full GPU), 0 for CPU only.',
+    tooltip:
+      'Controls how many transformer layers are offloaded to the GPU. ' +
+      'Set to -1 to offload all layers for maximum GPU utilisation. ' +
+      'Set to 0 to run entirely on CPU. ' +
+      'Values between 1 and the model\'s total layer count allow partial offloading when VRAM is limited.'
   },
   models_preset: {
     label: 'Models Preset Path',
     placeholder: '/path/to/preset.ini',
-    description: 'Optional: Path to preset.ini for router mode. Leave empty for normal operation, or use Preset tab to auto-generate'
+    description: 'Path to a preset.ini that defines multiple models for router mode. Leave empty or use the Preset tab.',
+    tooltip:
+      'Router mode allows one llama-server instance to serve multiple models on demand. ' +
+      'A preset.ini file defines each model\'s name and options. ' +
+      'Leave this empty and use the Preset tab to have llamactl generate and manage the file automatically, ' +
+      'or provide an absolute path to an existing preset.ini you maintain yourself.'
   }
 }
 
@@ -129,15 +160,18 @@ export function getAdvancedBackendFields(backendType?: string): string[] {
   return fieldGetter().filter(key => !(key in basicConfig) && key !== 'extra_args')
 }
 
-// Combined backend fields config for use in BackendFormField
+// Combined backend fields config for use in BackendFormField.
+// llama.cpp is spread last so its per-field labels/descriptions take precedence
+// over the generic vLLM/MLX ones for keys that appear in multiple backends (e.g. "model").
 export const basicBackendFieldsConfig: Record<string, {
   label: string
   description?: string
   placeholder?: string
+  tooltip?: string
 }> = {
-  ...basicLlamaCppFieldsConfig,
+  ...basicVllmFieldsConfig,
   ...basicMlxFieldsConfig,
-  ...basicVllmFieldsConfig
+  ...basicLlamaCppFieldsConfig,
 }
 
 // Get field type for any backend option (union type)


### PR DESCRIPTION
## Summary

This PR addresses three pain points in the llamactl web UI:

### 1. Router mode is now explained during instance creation

When creating a llama.cpp instance without specifying a model, `hf_repo`, or a preset, the Backend tab now shows a blue informational callout explaining that llama-server will start in router mode and may auto-discover cached HF model presets. It lists the three ways to configure a specific model (local path, HF repo+file, or Preset tab), so users are not surprised by unexpected multi-model behaviour.

The callout disappears as soon as any of those fields are filled in.

### 2. Instance card shows live model status

The instance card now polls model state every 10 seconds while an instance is running (previously it fetched once on mount and never updated again):

- **Single-model instance**: shows the loaded model's id/alias as a badge directly on the card.
- **Multi-model / router instance**: keeps the existing `X/N models` count badge, but it now stays current after load/unload operations without a manual page refresh.
- **Models dialog**: fires a callback immediately after any load or unload action so the card badge refreshes at once, not just when the next poll fires.

### 3. Field labels, descriptions, and tooltips improved

- `hf_repo` placeholder changed from `microsoft/DialoGPT-medium` (a vLLM example) to `ggml-org/gemma-3-1b-it-GGUF`, which is a GGUF repository.
- `hf_file` added as a basic llama.cpp field with an example filename.
- `model`, `hf_repo`, `hf_file`, `gpu_layers`, and `models_preset` all received expanded descriptions and tooltip text (shown via a small `?` icon next to the label).
- Fixed merge order in `basicBackendFieldsConfig` so llama.cpp field metadata takes precedence over the vLLM config for shared keys such as `model`.
- `GeneralTab`: expanded descriptions for instance name, group, idle timeout, and on-demand start fields.

## Tests

All 68 frontend tests pass (`npm run test:run`), type-check is clean (`npm run type-check`), and the build completes without errors (`npm run build`).

New test coverage added:
- `InstanceCard`: single-model badge display, multi-model badge display, no badge on stopped instance, polling interval setup.
- `InstanceModal`: router mode callout shows on Backend tab when no model is set; callout absent when editing an instance that already has a model configured.

## Testing context

These changes were developed and tested against a local llamactl instance running two llama.cpp instances (a router-mode instance serving 6 cached models, and a direct Qwen3.6-35B instance).

---
> **Note:** This replaces PR #224, which was closed because unrelated commits had been pushed to that branch after the PR was opened. This branch contains only the changes described above.

Co-Authored-By: Oz <oz-agent@warp.dev>