### PR TITLE
Show all instance card actions by default

### DIFF
--- a/webui/src/__tests__/App.test.tsx
+++ b/webui/src/__tests__/App.test.tsx
@@ -207,7 +207,6 @@ describe('App Component - Critical Business Logic Only', () => {
       expect(screen.getAllByTitle('Start instance').length).toBeGreaterThan(0)
       expect(screen.getAllByTitle('Stop instance').length).toBeGreaterThan(0)
       expect(screen.getAllByTitle('Edit instance').length).toBe(2)
-      expect(screen.getAllByTitle('More actions').length).toBe(2)
     })
 
     it('delete confirmation calls correct API', async () => {
@@ -221,17 +220,16 @@ describe('App Component - Critical Business Logic Only', () => {
         expect(screen.getByText('test-instance-1')).toBeInTheDocument()
       })
 
-      // First click the "More actions" button to reveal the delete button
-      const moreActionsButtons = screen.getAllByTitle('More actions')
-      await user.click(moreActionsButtons[0])
-
-      // Wait for the delete button to appear and click it
+      // Wait for the delete buttons to appear and click the enabled one
+      // (test-instance-1 is stopped so its delete button is enabled;
+      // test-instance-2 is running so its delete button is disabled)
       await waitFor(() => {
-        expect(screen.getByTitle('Delete instance')).toBeInTheDocument()
+        expect(screen.getAllByTitle('Delete instance').length).toBeGreaterThan(0)
       })
 
-      const deleteButton = screen.getByTitle('Delete instance')
-      await user.click(deleteButton)
+      const deleteButton = screen.getAllByTitle('Delete instance').find(button => !button.hasAttribute('disabled'))
+      expect(deleteButton).toBeTruthy()
+      await user.click(deleteButton!)
 
       // Verify confirmation and API call
       expect(confirmSpy).toHaveBeenCalledWith('Are you sure you want to delete instance "test-instance-1"?')

--- a/webui/src/components/InstanceCard.tsx
+++ b/webui/src/components/InstanceCard.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import type { Instance } from "@/types/instance";
-import { Edit, ExternalLink, FileText, Play, Square, Trash2, MoreHorizontal, Download, Boxes, Layers } from "lucide-react";
+import { Edit, ExternalLink, FileText, Play, Square, Trash2, Download, Boxes, Layers } from "lucide-react";
 import LogsDialog from "@/components/LogDialog";
 import ModelsDialog from "@/components/ModelsDialog";
 import HealthBadge from "@/components/HealthBadge";
@@ -29,7 +29,6 @@ function InstanceCard({
 }: InstanceCardProps) {
   const [isLogsOpen, setIsLogsOpen] = useState(false);
   const [isModelsOpen, setIsModelsOpen] = useState(false);
-  const [showAllActions, setShowAllActions] = useState(false);
   const [models, setModels] = useState<Model[]>([]);
   const health = useInstanceHealth(instance.name, instance.status);
 
@@ -178,80 +177,69 @@ function InstanceCard({
             >
               <Edit className="h-4 w-4" />
             </Button>
+          </div>
+
+          {/* Secondary actions */}
+          <div className="flex items-center gap-2 pt-2 border-t border-border flex-wrap">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleLogs}
+              title="View logs"
+              data-testid="view-logs-button"
+            >
+              <FileText className="h-4 w-4 mr-1" />
+              Logs
+            </Button>
+
+            {isLlamaCpp && running && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => window.open(`${document.baseURI}api/v1/instances/${instance.name}/proxy/`, "_blank")}
+                title="Open llama-server UI"
+                data-testid="open-llama-ui-button"
+              >
+                <ExternalLink className="h-4 w-4 mr-1" />
+                Server UI
+              </Button>
+            )}
+
+            {isLlamaCpp && totalModels > 1 && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleModels}
+                title="Manage models"
+                data-testid="manage-models-button"
+              >
+                <Boxes className="h-4 w-4 mr-1" />
+                Models
+              </Button>
+            )}
 
             <Button
               size="sm"
               variant="outline"
-              onClick={() => setShowAllActions(!showAllActions)}
-              title="More actions"
+              onClick={handleExport}
+              title="Export instance"
+              data-testid="export-instance-button"
             >
-              <MoreHorizontal className="h-4 w-4" />
+              <Download className="h-4 w-4 mr-1" />
+              Export
+            </Button>
+
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={running}
+              title="Delete instance"
+              data-testid="delete-instance-button"
+            >
+              <Trash2 className="h-4 w-4" />
             </Button>
           </div>
-
-          {/* Secondary actions - collapsible */}
-          {showAllActions && (
-            <div className="flex items-center gap-2 pt-2 border-t border-border flex-wrap">
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={handleLogs}
-                title="View logs"
-                data-testid="view-logs-button"
-              >
-                <FileText className="h-4 w-4 mr-1" />
-                Logs
-              </Button>
-
-              {isLlamaCpp && running && (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => window.open(`${document.baseURI}api/v1/instances/${instance.name}/proxy/`, "_blank")}
-                  title="Open llama-server UI"
-                  data-testid="open-llama-ui-button"
-                >
-                  <ExternalLink className="h-4 w-4 mr-1" />
-                  Server UI
-                </Button>
-              )}
-
-              {isLlamaCpp && totalModels > 1 && (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={handleModels}
-                  title="Manage models"
-                  data-testid="manage-models-button"
-                >
-                  <Boxes className="h-4 w-4 mr-1" />
-                  Models
-                </Button>
-              )}
-
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={handleExport}
-                title="Export instance"
-                data-testid="export-instance-button"
-              >
-                <Download className="h-4 w-4 mr-1" />
-                Export
-              </Button>
-
-              <Button
-                size="sm"
-                variant="destructive"
-                onClick={handleDelete}
-                disabled={running}
-                title="Delete instance"
-                data-testid="delete-instance-button"
-              >
-                <Trash2 className="h-4 w-4" />
-              </Button>
-            </div>
-          )}
         </CardContent>
       </Card>
 

--- a/webui/src/components/__tests__/InstanceCard.test.tsx
+++ b/webui/src/components/__tests__/InstanceCard.test.tsx
@@ -119,10 +119,6 @@ afterEach(() => {
         />
       )
 
-      // First click "More actions" to reveal the logs button
-      const moreActionsButton = screen.getByTitle('More actions')
-      await user.click(moreActionsButton)
-
       const logsButton = screen.getByTitle('View logs')
       await user.click(logsButton)
 
@@ -145,10 +141,6 @@ afterEach(() => {
           editInstance={mockEditInstance}
         />
       )
-
-      // First click "More actions" to reveal the delete button
-      const moreActionsButton = screen.getByTitle('More actions')
-      await user.click(moreActionsButton)
 
       const deleteButton = screen.getByTitle('Delete instance')
       await user.click(deleteButton)
@@ -173,10 +165,6 @@ afterEach(() => {
         />
       )
 
-      // First click "More actions" to reveal the delete button
-      const moreActionsButton = screen.getByTitle('More actions')
-      await user.click(moreActionsButton)
-
       const deleteButton = screen.getByTitle('Delete instance')
       await user.click(deleteButton)
 
@@ -188,9 +176,7 @@ afterEach(() => {
   })
 
   describe('Button State Based on Instance Status', () => {
-    it('disables start button and enables stop button for running instance', async () => {
-      const user = userEvent.setup()
-
+    it('disables start button and enables stop button for running instance', () => {
       render(
         <InstanceCard
           instance={runningInstance}
@@ -204,16 +190,10 @@ afterEach(() => {
       expect(screen.queryByTitle('Start instance')).not.toBeInTheDocument()
       expect(screen.getByTitle('Stop instance')).not.toBeDisabled()
 
-      // Expand more actions to access delete button
-      const moreActionsButton = screen.getByTitle('More actions')
-      await user.click(moreActionsButton)
-
       expect(screen.getByTitle('Delete instance')).toBeDisabled() // Can't delete running instance
     })
 
-    it('enables start button and disables stop button for stopped instance', async () => {
-      const user = userEvent.setup()
-
+    it('enables start button and disables stop button for stopped instance', () => {
       render(
         <InstanceCard
           instance={stoppedInstance}
@@ -227,16 +207,10 @@ afterEach(() => {
       expect(screen.getByTitle('Start instance')).not.toBeDisabled()
       expect(screen.queryByTitle('Stop instance')).not.toBeInTheDocument()
 
-      // Expand more actions to access delete button
-      const moreActionsButton = screen.getByTitle('More actions')
-      await user.click(moreActionsButton)
-
       expect(screen.getByTitle('Delete instance')).not.toBeDisabled() // Can delete stopped instance
     })
 
-    it('edit and logs buttons are always enabled', async () => {
-      const user = userEvent.setup()
-
+    it('edit and logs buttons are always enabled', () => {
       render(
         <InstanceCard
           instance={runningInstance}
@@ -248,10 +222,6 @@ afterEach(() => {
       )
 
       expect(screen.getByTitle('Edit instance')).not.toBeDisabled()
-
-      // Expand more actions to access logs button
-      const moreActionsButton = screen.getByTitle('More actions')
-      await user.click(moreActionsButton)
 
       expect(screen.getByTitle('View logs')).not.toBeDisabled()
     })
@@ -317,10 +287,6 @@ afterEach(() => {
           editInstance={mockEditInstance}
         />
       )
-
-      // First click "More actions" to reveal the logs button
-      const moreActionsButton = screen.getByTitle('More actions')
-      await user.click(moreActionsButton)
 
       // Open logs dialog
       await user.click(screen.getByTitle('View logs'))


### PR DESCRIPTION
## Summary
- Removes the "..." overflow toggle on the instance card so Logs, Server UI, Models, and Export are always visible instead of requiring an extra click to reveal them.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm test` (updated `InstanceCard.test.tsx` and `App.test.tsx` for the removed overflow button)