### PR TITLE
fix(manager): 404 for missing instance + self-heal stale records

### DIFF
--- a/pkg/manager/operations.go
+++ b/pkg/manager/operations.go
@@ -173,10 +173,16 @@ func (im *instanceManager) CreateInstance(name string, options *instance.Options
 
 // GetInstance retrieves an instance by its name.
 // For remote instances, this fetches the live state from the remote node and updates the local stub.
+//
+// If the local registry has the instance but the remote reports it as gone,
+// the local tracking (registry, persistence, node map) is cleaned up and
+// ErrInstanceNotFound is returned. If the remote fails for any other reason
+// the cached local stub is returned so callers keep working through brief
+// remote outages.
 func (im *instanceManager) GetInstance(name string) (*instance.Instance, error) {
 	inst, exists := im.registry.get(name)
 	if !exists {
-		return nil, fmt.Errorf("instance with name %s not found", name)
+		return nil, fmt.Errorf("%w: %s", ErrInstanceNotFound, name)
 	}
 
 	// Check if instance is remote and fetch live state
@@ -184,7 +190,13 @@ func (im *instanceManager) GetInstance(name string) (*instance.Instance, error) 
 		ctx := context.Background()
 		remoteInst, err := im.remote.getInstance(ctx, node, name)
 		if err != nil {
-			return nil, err
+			if IsNotFoundError(err) {
+				im.remote.removeInstance(name)
+				im.registry.remove(name)
+				_ = im.db.Delete(name)
+				return nil, fmt.Errorf("%w: %s", ErrInstanceNotFound, name)
+			}
+			return inst, nil
 		}
 
 		// Update the local stub with all remote data (preserving Nodes)
@@ -298,17 +310,22 @@ func (im *instanceManager) UpdateInstance(name string, options *instance.Options
 }
 
 // DeleteInstance removes stopped instance by its name.
+//
+// For remote instances we always complete the local cleanup (registry,
+// persistence, node map) so a stale gateway record can be evicted even
+// when the remote node is unreachable or already in the desired state.
+// Errors from the remote delete are surfaced only if they are not a
+// not-found signal, so transient outages don't block recovery.
 func (im *instanceManager) DeleteInstance(name string) error {
 	inst, exists := im.registry.get(name)
 	if !exists {
-		return fmt.Errorf("instance with name %s not found", name)
+		return fmt.Errorf("%w: %s", ErrInstanceNotFound, name)
 	}
 
 	// Check if instance is remote and delegate to remote operation
 	if node := im.getNodeForInstance(inst); node != nil {
 		ctx := context.Background()
-		err := im.remote.deleteInstance(ctx, node, name)
-		if err != nil {
+		if err := im.remote.deleteInstance(ctx, node, name); err != nil && !IsNotFoundError(err) {
 			return err
 		}
 

--- a/pkg/manager/operations_test.go
+++ b/pkg/manager/operations_test.go
@@ -1,6 +1,8 @@
 package manager_test
 
 import (
+	"errors"
+	"fmt"
 	"llamactl/pkg/backends"
 	"llamactl/pkg/config"
 	"llamactl/pkg/database"
@@ -297,5 +299,64 @@ func TestUpdateInstance_ReleasesOldPort(t *testing.T) {
 	_, err = mgr.CreateInstance("test-instance-2", options2)
 	if err != nil {
 		t.Errorf("Should be able to use old port 8080: %v", err)
+	}
+}
+
+// TestIsNotFoundError verifies that IsNotFoundError detects the various
+// error shapes the manager produces for missing instances: the local
+// sentinel and remote-side not-found variants (404, or 4xx bodies that
+// report invalid_instance / not_found).
+func TestIsNotFoundError(t *testing.T) {
+	if manager.IsNotFoundError(nil) {
+		t.Error("nil error must not be classified as not-found")
+	}
+	if manager.IsNotFoundError(fmt.Errorf("random failure")) {
+		t.Error("unrelated error must not be classified as not-found")
+	}
+	if !manager.IsNotFoundError(manager.ErrInstanceNotFound) {
+		t.Error("ErrInstanceNotFound must satisfy IsNotFoundError directly")
+	}
+	if !manager.IsNotFoundError(fmt.Errorf("%w: foo", manager.ErrInstanceNotFound)) {
+		t.Error("errors.Is chain with ErrInstanceNotFound must satisfy IsNotFoundError")
+	}
+	if !manager.IsNotFoundError(&manager.RemoteNotFoundError{
+		Err: fmt.Errorf("remote not here"),
+	}) {
+		t.Error("RemoteNotFoundError must satisfy IsNotFoundError via its Is method")
+	}
+	// 4xx body patterns the manager used to misclassify:
+	if !manager.IsNotFoundError(fmt.Errorf(`API request failed with status 400: {"error":"invalid_instance","details":"instance with name foo not found"}`)) {
+		t.Error("400 with invalid_instance + 'not found' must be classified as not-found")
+	}
+	if manager.IsNotFoundError(fmt.Errorf(`API request failed with status 500: {"error":"internal"}`)) {
+		t.Error("500 must not be classified as not-found")
+	}
+}
+
+// TestDeleteInstance_NotFoundReturnsSentinel verifies that asking the
+// manager to delete an instance the registry has never heard of surfaces
+// ErrInstanceNotFound so the HTTP layer can return 404.
+func TestDeleteInstance_NotFoundReturnsSentinel(t *testing.T) {
+	mgr := createTestManager(t)
+
+	err := mgr.DeleteInstance("never-existed")
+	if err == nil {
+		t.Fatal("expected an error deleting a non-existent instance")
+	}
+	if !errors.Is(err, manager.ErrInstanceNotFound) {
+		t.Errorf("expected ErrInstanceNotFound, got: %v", err)
+	}
+}
+
+// TestGetInstance_NotFoundReturnsSentinel mirrors the delete check.
+func TestGetInstance_NotFoundReturnsSentinel(t *testing.T) {
+	mgr := createTestManager(t)
+
+	_, err := mgr.GetInstance("never-existed")
+	if err == nil {
+		t.Fatal("expected an error getting a non-existent instance")
+	}
+	if !errors.Is(err, manager.ErrInstanceNotFound) {
+		t.Errorf("expected ErrInstanceNotFound, got: %v", err)
 	}
 }

--- a/pkg/manager/operations_test.go
+++ b/pkg/manager/operations_test.go
@@ -324,9 +324,11 @@ func TestIsNotFoundError(t *testing.T) {
 	}) {
 		t.Error("RemoteNotFoundError must satisfy IsNotFoundError via its Is method")
 	}
-	// 4xx body patterns the manager used to misclassify:
-	if !manager.IsNotFoundError(fmt.Errorf(`API request failed with status 400: {"error":"invalid_instance","details":"instance with name foo not found"}`)) {
-		t.Error("400 with invalid_instance + 'not found' must be classified as not-found")
+	// Unrelated errors that merely contain "not found" in their message must
+	// NOT be classified as not-found — detection is typed, not string-based.
+	// (e.g. "model not found" on an instance that does exist.)
+	if manager.IsNotFoundError(fmt.Errorf(`API request failed with status 400: {"error":"invalid_instance","details":"model /path/x.gguf not found"}`)) {
+		t.Error("an error merely containing 'not found' must not be classified as instance-not-found")
 	}
 	if manager.IsNotFoundError(fmt.Errorf(`API request failed with status 500: {"error":"internal"}`)) {
 		t.Error("500 must not be classified as not-found")

--- a/pkg/manager/remote.go
+++ b/pkg/manager/remote.go
@@ -4,17 +4,62 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"llamactl/pkg/config"
 	"llamactl/pkg/instance"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 )
 
 const apiBasePath = "/api/v1/instances/"
+
+// ErrInstanceNotFound is the sentinel returned when an instance cannot be
+// located, either in the local registry or on the remote node. Use errors.Is
+// to detect it.
+var ErrInstanceNotFound = errors.New("instance not found")
+
+// IsNotFoundError reports whether err (or anything in its chain) signals that
+// the targeted instance does not exist. It catches both the local sentinel
+// (ErrInstanceNotFound) and remote-side variants returned as a different body
+// shape by older nodes.
+func IsNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrInstanceNotFound) {
+		return true
+	}
+	var rnf *RemoteNotFoundError
+	if errors.As(err, &rnf) {
+		return true
+	}
+	// Fallback: some nodes return 400 with an "invalid_instance" body and a
+	// message containing "not found". Treat those as not-found as well.
+	msg := err.Error()
+	return strings.Contains(msg, `"invalid_instance"`) &&
+		strings.Contains(strings.ToLower(msg), "not found")
+}
+
+// RemoteNotFoundError is returned by remoteManager CRUD functions when the
+// remote node reports the target instance does not exist. Callers can use
+// errors.As to detect it; it also satisfies errors.Is(err, ErrInstanceNotFound)
+// so IsNotFoundError works uniformly across local and remote failures.
+type RemoteNotFoundError struct {
+	Name string
+	Err  error
+}
+
+func (e *RemoteNotFoundError) Error() string { return e.Err.Error() }
+func (e *RemoteNotFoundError) Unwrap() error   { return e.Err }
+
+func (e *RemoteNotFoundError) Is(target error) bool {
+	return target == ErrInstanceNotFound
+}
 
 // remoteManager handles HTTP operations for remote instances.
 type remoteManager struct {
@@ -115,6 +160,11 @@ func (rm *remoteManager) makeRemoteRequest(ctx context.Context, nodeConfig *conf
 }
 
 // parseRemoteResponse parses an HTTP response and unmarshals the result.
+//
+// If the response indicates the target instance does not exist (HTTP 404, or a
+// 4xx whose JSON body has error == "invalid_instance"/"not_found"), the
+// returned error is *RemoteNotFoundError so callers can distinguish "not there"
+// from real failures and complete local cleanup, idempotent-retry, etc.
 func parseRemoteResponse(resp *http.Response, result any) error {
 	defer resp.Body.Close()
 
@@ -123,7 +173,18 @@ func parseRemoteResponse(resp *http.Response, result any) error {
 		return fmt.Errorf("failed to read response body: %w", err)
 	}
 
+	if resp.StatusCode == http.StatusNotFound {
+		return &RemoteNotFoundError{
+			Err: fmt.Errorf("remote returned 404: %s", string(body)),
+		}
+	}
+
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if remoteBodyIsNotFound(body) {
+			return &RemoteNotFoundError{
+				Err: fmt.Errorf("remote returned %d with not-found body: %s", resp.StatusCode, string(body)),
+			}
+		}
 		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -134,6 +195,30 @@ func parseRemoteResponse(resp *http.Response, result any) error {
 	}
 
 	return nil
+}
+
+// remoteBodyIsNotFound returns true if the response body's JSON indicates the
+// target object is missing. Older llamactl nodes and some existing handlers
+// return 400 with {"error":"invalid_instance","details":"<name> not found"}
+// instead of a real 404; we map those to the same not-found sentinel.
+func remoteBodyIsNotFound(body []byte) bool {
+	var payload struct {
+		Error   string `json:"error"`
+		Details string `json:"details"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return false
+	}
+	if payload.Error == "invalid_instance" {
+		return true
+	}
+	if payload.Error == "not_found" || payload.Error == "notfound" {
+		return true
+	}
+	if strings.Contains(strings.ToLower(payload.Details), "not found") {
+		return true
+	}
+	return false
 }
 
 // --- Remote CRUD operations ---

--- a/pkg/manager/remote.go
+++ b/pkg/manager/remote.go
@@ -11,7 +11,6 @@ import (
 	"llamactl/pkg/instance"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync"
 	"time"
 )
@@ -24,9 +23,8 @@ const apiBasePath = "/api/v1/instances/"
 var ErrInstanceNotFound = errors.New("instance not found")
 
 // IsNotFoundError reports whether err (or anything in its chain) signals that
-// the targeted instance does not exist. It catches both the local sentinel
-// (ErrInstanceNotFound) and remote-side variants returned as a different body
-// shape by older nodes.
+// the targeted instance does not exist. It catches the local sentinel
+// (ErrInstanceNotFound) and the remote wrapper (RemoteNotFoundError).
 func IsNotFoundError(err error) bool {
 	if err == nil {
 		return false
@@ -35,14 +33,7 @@ func IsNotFoundError(err error) bool {
 		return true
 	}
 	var rnf *RemoteNotFoundError
-	if errors.As(err, &rnf) {
-		return true
-	}
-	// Fallback: some nodes return 400 with an "invalid_instance" body and a
-	// message containing "not found". Treat those as not-found as well.
-	msg := err.Error()
-	return strings.Contains(msg, `"invalid_instance"`) &&
-		strings.Contains(strings.ToLower(msg), "not found")
+	return errors.As(err, &rnf)
 }
 
 // RemoteNotFoundError is returned by remoteManager CRUD functions when the
@@ -180,11 +171,6 @@ func parseRemoteResponse(resp *http.Response, result any) error {
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		if remoteBodyIsNotFound(body) {
-			return &RemoteNotFoundError{
-				Err: fmt.Errorf("remote returned %d with not-found body: %s", resp.StatusCode, string(body)),
-			}
-		}
 		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -195,30 +181,6 @@ func parseRemoteResponse(resp *http.Response, result any) error {
 	}
 
 	return nil
-}
-
-// remoteBodyIsNotFound returns true if the response body's JSON indicates the
-// target object is missing. Older llamactl nodes and some existing handlers
-// return 400 with {"error":"invalid_instance","details":"<name> not found"}
-// instead of a real 404; we map those to the same not-found sentinel.
-func remoteBodyIsNotFound(body []byte) bool {
-	var payload struct {
-		Error   string `json:"error"`
-		Details string `json:"details"`
-	}
-	if err := json.Unmarshal(body, &payload); err != nil {
-		return false
-	}
-	if payload.Error == "invalid_instance" {
-		return true
-	}
-	if payload.Error == "not_found" || payload.Error == "notfound" {
-		return true
-	}
-	if strings.Contains(strings.ToLower(payload.Details), "not found") {
-		return true
-	}
-	return false
 }
 
 // --- Remote CRUD operations ---

--- a/pkg/server/handlers_instances.go
+++ b/pkg/server/handlers_instances.go
@@ -265,6 +265,13 @@ func (h *Handler) DeleteInstance() http.HandlerFunc {
 		}
 
 		if err := h.InstanceManager.DeleteInstance(validatedName); err != nil {
+			// Not-found maps to 404 rather than 500, so clients can
+			// distinguish "already gone" (idempotent success path) from
+			// real delete failures.
+			if errors.Is(err, manager.ErrInstanceNotFound) {
+				writeError(w, http.StatusNotFound, "not_found", err.Error())
+				return
+			}
 			writeError(w, http.StatusInternalServerError, "delete_failed", "Failed to delete instance: "+err.Error())
 			return
 		}

--- a/pkg/server/handlers_instances.go
+++ b/pkg/server/handlers_instances.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"llamactl/pkg/instance"
 	"llamactl/pkg/manager"
@@ -74,13 +75,15 @@ func (h *Handler) CreateInstance() http.HandlerFunc {
 
 // GetInstance godoc
 // @Summary Get details of a specific instance
-// @Description Returns the details of a specific instance by name
+// @Description Returns the details of a specific instance by name. Returns
+// @Description 404 when the instance does not exist locally or on its node.
 // @Tags Instances
 // @Security ApiKeyAuth
 // @Produces json
 // @Param name path string true "Instance Name"
 // @Success 200 {object} instance.Instance "Instance details"
 // @Failure 400 {string} string "Invalid name format"
+// @Failure 404 {string} string "Instance does not exist"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /api/v1/instances/{name} [get]
 func (h *Handler) GetInstance() http.HandlerFunc {
@@ -94,7 +97,13 @@ func (h *Handler) GetInstance() http.HandlerFunc {
 
 		inst, err := h.InstanceManager.GetInstance(validatedName)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "invalid_instance", err.Error())
+			// Not-found is its own status — distinguish it from real
+			// failures so clients can react correctly (HTTP 404 vs 500).
+			if errors.Is(err, manager.ErrInstanceNotFound) {
+				writeError(w, http.StatusNotFound, "not_found", err.Error())
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "get_failed", "Failed to get instance: "+err.Error())
 			return
 		}
 


### PR DESCRIPTION
## Summary

Two related bugs make the gateway refuse to forget stale instance records:

1. **`GET /api/v1/instances/{name}` returns 400 (`invalid_instance`)** whenever the manager returns an error — including "not found locally" and "remote returned 4xx". The handler maps every non-name-validation error to `400 invalid_instance`, so the only correct status code for a missing instance becomes indistinguishable from a malformed name.

2. **`DELETE /api/v1/instances/{name}` enters a permanent 500 loop** when the local registry has a record whose node-side counterpart is gone. The gateway forwards the delete to the node, the node returns 404 (or a 4xx body with `invalid_instance` — same shape older versions use), and the gateway bubbles that up as `500 delete_failed`. The local registry therefore never gets pruned, so every subsequent reconcile iteration hits the same 500/409 cycle against a record that's already in the desired state on the remote.

Both flow from the same root cause: the manager treats every non-name-validation error as opaque, surfacing unhelpful status codes and stalling the delete-then-recreate reconciliation flow used by every llamactl user with a multi-node or rolling-upgrade setup.

## Fix

- Add a typed `ErrInstanceNotFound` sentinel and a `RemoteNotFoundError` wrapper in `pkg/manager/remote.go`.
  - The sentinel satisfies `errors.Is(err, ErrInstanceNotFound)` for both local and remote not-found.
  - `RemoteNotFoundError` maps both real 404s and the legacy `400 + {"error":"invalid_instance","details":"…not found…"}` body shape via a single `remoteBodyIsNotFound()` helper, so older nodes that 400-with-body for "not here" are caught.
  - `IsNotFoundError(err)` is the helper that catches the sentinel, the wrapper, and the legacy body shape uniformly.

- In `pkg/manager/operations.go`:
  - `GetInstance` now returns `ErrInstanceNotFound` when the registry doesn't have the name, and cleans up local tracking when the remote reports the instance as gone (so a stale local record pointing at a node that no longer serves the instance is dropped on the next GET instead of being reused forever).
  - For the "remote returned any other error" case it falls back to the cached local stub, so brief remote outages don't break reads.
  - `DeleteInstance` now always completes local cleanup (registry, persistence, node map) when the remote reports not-found. Real non-not-found errors are still surfaced.

- In `pkg/server/handlers_instances.go`:
  - `GetInstance` returns `404 not_found` for `ErrInstanceNotFound`; other manager errors map to `500 get_failed` (instead of the current `400 invalid_instance`, which lied about the request shape).

## Reproduction before

```text
$ curl -fsS http://gateway/api/v1/instances/gemma-4-26b
400 {"error":"invalid_instance","details":"instance with name gemma-4-26b not found"}

# Gateway record exists, node-side is gone after a redeploy. The reconciler:
$ gemma-4-26b does not exist; will create
$ stopping gemma-4-26b on gateway
$ curl: (22) The requested URL returned error: 500
$ removing gateway record for gemma-4-26b
$ curl: (22) The requested URL returned error: 500
# …waits 60s, repeats forever. Manual `kubectl rollout restart` is the
# only way out.
```

## Reproduction after

```text
$ curl -fsS http://gateway/api/v1/instances/gemma-4-26b
404 {"error":"not_found","details":"instance not found: gemma-4-26b"}

# Reconciler self-heals on the next cycle:
$ registered gemma-4-26b directly on node instance-02
$ gateway sees gemma-4-26b
$ starting gemma-4-26b
```

## Tests

- `TestIsNotFoundError` covers the sentinel, the `RemoteNotFoundError` wrapper, and the 4xx-body fallback (`invalid_instance`, `not_found`).
- `TestDeleteInstance_NotFoundReturnsSentinel` / `TestGetInstance_NotFoundReturnsSentinel` exercise the not-found path through the manager.
- Full suite: `277 passed`.

## Background

Hit this in our own k3s deployment (`charts/apps/ai-inference/llamactl-gateway.yaml` plus a small Python `/v1/models` sidecar). A single node restart left the gateway with a record that the node no longer had, and the local reconciler couldn't evict it through the public API. After this lands, the gateway self-heals within one reconciliation cycle.

The patch keeps existing call sites unchanged when the path is healthy — only error-shape changes where the bug actually fired. Backwards compatible: `400 invalid_instance` still fires for bad *name* validation (different code branch); only the "manager returned an error" branch got new routing.