### PR TITLE
fix: instance lifecycle — double-spawn guard, group limits, reliable Windows stop

### DIFF
--- a/pkg/instance/process.go
+++ b/pkg/instance/process.go
@@ -182,10 +182,9 @@ func (p *process) stop() error {
 	p.instance.SetStatus(Stopped)
 
 	// Graceful stop: close stdin (EOF is a shutdown request where the
-	// backend honors it), then deliver the platform interrupt — Ctrl-C on
-	// the child's own console on Windows (llama.cpp installs a
-	// SetConsoleCtrlHandler that stops the server cleanly; SIGINT is a
-	// no-op for children there), SIGINT on Unix.
+	// backend honors it), then the platform interrupt (SIGINT on Unix).
+	// On Windows SIGINT/Ctrl-C do not reach the child, so the force-kill
+	// below is the reliable stop; the shorter grace there trims the wait.
 	if p.stdin != nil {
 		if cerr := p.stdin.Close(); cerr != nil {
 			log.Printf("Failed to close stdin for instance %s: %v", p.instance.Name, cerr)
@@ -200,10 +199,10 @@ func (p *process) stop() error {
 		return nil
 	}
 
-	// Wait for the process to exit after the shutdown signal. A graceful
-	// stop (Ctrl-C/SIGINT) usually finishes in a second or two; the long
-	// grace is the safety net. On Windows the force-kill fallback is
-	// slightly more aggressive, so use a shorter grace there.
+	// Wait for the process to exit after the shutdown signal. On Unix a
+	// SIGINT graceful stop usually finishes in a second or two and the long
+	// grace is the safety net. On Windows the stop is the force-kill, so use
+	// a shorter grace there to avoid a slow shutdown.
 	killGrace := 30 * time.Second
 	if runtime.GOOS == "windows" {
 		killGrace = 5 * time.Second

--- a/pkg/instance/process.go
+++ b/pkg/instance/process.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"runtime"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -23,6 +23,7 @@ type process struct {
 	cmd           *exec.Cmd
 	ctx           context.Context
 	cancel        context.CancelFunc
+	stdin         io.Closer
 	stdout        io.ReadCloser
 	stderr        io.ReadCloser
 	restarts      int
@@ -77,11 +78,37 @@ func (p *process) start() error {
 	}
 	p.cmd = cmd
 
-	if runtime.GOOS != "windows" {
-		setProcAttrs(p.cmd)
+	// Double-spawn guard: if our port is already accepting connections, a
+	// surviving llama-server from a previous (or crashed) start is still
+	// bound to it. Waiting it out avoids double-binding, which would run
+	// two copies of the model in VRAM at once.
+	host, port := p.instance.options.GetHost(), p.instance.options.GetPort()
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	if port > 0 {
+		deadline := time.Now().Add(15 * time.Second)
+		for portInUse(host, port) {
+			if time.Now().After(deadline) {
+				p.instance.logger.close()
+				if p.cancel != nil {
+					p.cancel()
+				}
+				return fmt.Errorf("port %s:%d is still occupied by a surviving process; refusing to start a second server on it (find it with: netstat -ano | findstr %d)", host, port, port)
+			}
+			log.Printf("Instance %s: port %d still in use, waiting for it to be released...", p.instance.Name, port)
+			time.Sleep(500 * time.Millisecond)
+		}
 	}
 
+	setProcAttrs(p.cmd)
+
 	var err error
+	p.stdin, err = p.cmd.StdinPipe()
+	if err != nil {
+		p.instance.logger.close()
+		return fmt.Errorf("failed to get stdin pipe: %w", err)
+	}
 	p.stdout, err = p.cmd.StdoutPipe()
 	if err != nil {
 		p.instance.logger.close()
@@ -154,12 +181,18 @@ func (p *process) stop() error {
 	// Now set status to stopped to signal intentional stop
 	p.instance.SetStatus(Stopped)
 
-	// Stop the process with SIGINT if cmd exists
-	if p.cmd != nil && p.cmd.Process != nil {
-		if err := p.cmd.Process.Signal(syscall.SIGINT); err != nil {
-			log.Printf("Failed to send SIGINT to instance %s: %v", p.instance.Name, err)
+	// Graceful stop: close stdin (EOF is a shutdown request where the
+	// backend honors it), then deliver the platform interrupt — Ctrl-C on
+	// the child's own console on Windows (llama.cpp installs a
+	// SetConsoleCtrlHandler that stops the server cleanly; SIGINT is a
+	// no-op for children there), SIGINT on Unix.
+	if p.stdin != nil {
+		if cerr := p.stdin.Close(); cerr != nil {
+			log.Printf("Failed to close stdin for instance %s: %v", p.instance.Name, cerr)
 		}
+		p.stdin = nil
 	}
+	signalStop(p.cmd)
 
 	// If no process exists, we can return immediately
 	if p.cmd == nil || monitorDone == nil {
@@ -167,11 +200,20 @@ func (p *process) stop() error {
 		return nil
 	}
 
+	// Wait for the process to exit after the shutdown signal. A graceful
+	// stop (Ctrl-C/SIGINT) usually finishes in a second or two; the long
+	// grace is the safety net. On Windows the force-kill fallback is
+	// slightly more aggressive, so use a shorter grace there.
+	killGrace := 30 * time.Second
+	if runtime.GOOS == "windows" {
+		killGrace = 5 * time.Second
+	}
+
 	select {
 	case <-monitorDone:
 		// Process exited normally
 		log.Printf("Instance %s shut down gracefully", p.instance.Name)
-	case <-time.After(30 * time.Second):
+	case <-time.After(killGrace):
 		// Force kill if it doesn't exit within 30 seconds
 		if p.cmd != nil && p.cmd.Process != nil {
 			killErr := p.cmd.Process.Kill()
@@ -184,7 +226,7 @@ func (p *process) stop() error {
 			select {
 			case <-monitorDone:
 				// Monitor completed after force kill
-			case <-time.After(2 * time.Second):
+			case <-time.After(10 * time.Second):
 				log.Printf("Warning: Monitor goroutine did not complete after force kill for instance %s", p.instance.Name)
 			}
 		}
@@ -277,18 +319,34 @@ func (p *process) waitForHealthy(timeout int) error {
 
 // monitorProcess monitors the OS process and handles crashes/exits
 func (p *process) monitorProcess() {
+	// Capture this generation's identity up front so a stale monitor
+	// (left over from a superseded start) can never close a newer
+	// monitor's completion channel or overwrite live instance state.
+	p.mu.Lock()
+	myCmd := p.cmd
+	myDone := p.monitorDone
+	p.mu.Unlock()
+
 	defer func() {
 		p.mu.Lock()
-		if p.monitorDone != nil {
-			close(p.monitorDone)
+		if myDone != nil && p.monitorDone == myDone {
+			close(myDone)
 			p.monitorDone = nil
 		}
 		p.mu.Unlock()
 	}()
 
-	err := p.cmd.Wait()
+	err := myCmd.Wait()
 
 	p.mu.Lock()
+
+	// Stale monitor: a newer start replaced p.cmd while we were waiting.
+	// The defer signals our channel; leave the live state untouched.
+	if p.cmd != myCmd {
+		log.Printf("Instance %s: ignoring exit of superseded process (stale monitor)", p.instance.Name)
+		p.mu.Unlock()
+		return
+	}
 
 	// Check if the instance was intentionally stopped
 	if !p.instance.IsRunning() {
@@ -425,4 +483,14 @@ func (p *process) buildCommand() (*exec.Cmd, error) {
 	}
 
 	return cmd, nil
+}
+
+// portInUse reports whether something is accepting TCP connections on host:port.
+func portInUse(host string, port int) bool {
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", host, port), 500*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
 }

--- a/pkg/instance/process_group_unix.go
+++ b/pkg/instance/process_group_unix.go
@@ -13,3 +13,11 @@ func setProcAttrs(cmd *exec.Cmd) {
 	}
 	cmd.SysProcAttr.Setpgid = true
 }
+
+// signalStop delivers SIGINT (os.Interrupt) to the child.
+func signalStop(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Signal(syscall.SIGINT)
+}

--- a/pkg/instance/process_group_windows.go
+++ b/pkg/instance/process_group_windows.go
@@ -2,31 +2,20 @@
 
 package instance
 
-import (
-	"os/exec"
-	"syscall"
-
-	windows "golang.org/x/sys/windows"
-)
+import "os/exec"
 
 func setProcAttrs(cmd *exec.Cmd) {
-	// Give the child its own (hidden) console so we can send it Ctrl-C
-	// later (GenerateConsoleCtrlEvent) for a graceful stop.
-	if cmd.SysProcAttr == nil {
-		cmd.SysProcAttr = &syscall.SysProcAttr{}
-	}
-	cmd.SysProcAttr.HideWindow = true
-	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NEW_CONSOLE
+	// No-op on Windows. (os.Interrupt/SIGINT are no-ops for child processes
+	// here, and GenerateConsoleCtrlEvent could not be delivered reliably to
+	// the child in a service session, so graceful stop falls back to the
+	// force-kill after a short grace in process.go.)
 }
 
-// signalStop delivers the platform "interrupt" to the child process.
-// On Windows that is Ctrl-C on the child's own console: llama.cpp
-// imports SetConsoleCtrlHandler and shuts the server down cleanly when
-// it fires. (os.Interrupt/SIGINT are no-ops for child processes on
-// Windows, so this is the real thing.)
+// signalStop is a no-op on Windows: SIGINT does not reach child processes
+// and the console Ctrl-C path proved unreliable, so the caller relies on
+// the force-kill after the grace period.
 func signalStop(cmd *exec.Cmd) {
 	if cmd == nil || cmd.Process == nil {
 		return
 	}
-	_ = windows.GenerateConsoleCtrlEvent(windows.CTRL_C_EVENT, uint32(cmd.Process.Pid))
 }

--- a/pkg/instance/process_group_windows.go
+++ b/pkg/instance/process_group_windows.go
@@ -2,8 +2,31 @@
 
 package instance
 
-import "os/exec"
+import (
+	"os/exec"
+	"syscall"
+
+	windows "golang.org/x/sys/windows"
+)
 
 func setProcAttrs(cmd *exec.Cmd) {
-	// No-op on Windows
+	// Give the child its own (hidden) console so we can send it Ctrl-C
+	// later (GenerateConsoleCtrlEvent) for a graceful stop.
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.HideWindow = true
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NEW_CONSOLE
+}
+
+// signalStop delivers the platform "interrupt" to the child process.
+// On Windows that is Ctrl-C on the child's own console: llama.cpp
+// imports SetConsoleCtrlHandler and shuts the server down cleanly when
+// it fires. (os.Interrupt/SIGINT are no-ops for child processes on
+// Windows, so this is the real thing.)
+func signalStop(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = windows.GenerateConsoleCtrlEvent(windows.CTRL_C_EVENT, uint32(cmd.Process.Pid))
 }

--- a/pkg/manager/lifecycle.go
+++ b/pkg/manager/lifecycle.go
@@ -94,6 +94,13 @@ func (l *lifecycleManager) checkTimeouts() {
 		}
 
 		if inst.ShouldTimeout() {
+			// Never idle-stop an instance that is actively serving a request:
+			// the stop path only gives in-flight work a 30 s grace, which is
+			// far too short for long generations.
+			if inflight := inst.GetInflightRequests(); inflight > 0 {
+				log.Printf("Instance %s timed out but has %d in-flight request(s); deferring idle stop", inst.Name, inflight)
+				continue
+			}
 			timeoutInstances = append(timeoutInstances, inst.Name)
 		}
 	}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -7,6 +7,7 @@ import (
 	"llamactl/pkg/database"
 	"llamactl/pkg/instance"
 	"log"
+	"sort"
 	"sync"
 	"time"
 )
@@ -233,8 +234,39 @@ func (im *instanceManager) autoStartInstances() {
 		im.registry.markStopped(inst.Name)
 	}
 
-	// Start instances that have auto-restart enabled
+	// Start instances that have auto-restart enabled. Enforce group and
+	// global limits: start the most recently used first and leave the rest
+	// stopped (they start on demand). Previously this started every
+	// persisted-running instance, which could boot two large models at
+	// once and spill VRAM into system RAM.
+	sort.Slice(instancesToStart, func(i, j int) bool {
+		return instancesToStart[i].LastRequestTime() > instancesToStart[j].LastRequestTime()
+	})
+
+	limits := im.globalConfig.Instances
+	groupRunning := map[string]int{}
+	started := 0
 	for _, inst := range instancesToStart {
+		group := ""
+		if inst.GetOptions() != nil {
+			group = inst.GetOptions().Group
+		}
+
+		if group != "" {
+			if limit, ok := limits.GroupLimits[group]; ok && limit > 0 && groupRunning[group] >= limit {
+				log.Printf("Instance %s: group %s already at boot limit (%d); leaving stopped (will start on demand)", inst.Name, group, limit)
+				inst.SetStatus(instance.Stopped)
+				im.registry.markStopped(inst.Name)
+				continue
+			}
+		}
+		if limits.MaxRunningInstances > 0 && started >= limits.MaxRunningInstances {
+			log.Printf("Instance %s: at global boot limit (%d); leaving stopped (will start on demand)", inst.Name, limits.MaxRunningInstances)
+			inst.SetStatus(instance.Stopped)
+			im.registry.markStopped(inst.Name)
+			continue
+		}
+
 		log.Printf("Auto-starting instance %s", inst.Name)
 		// Reset running state before starting (since Start() expects stopped instance)
 		inst.SetStatus(instance.Stopped)
@@ -251,8 +283,13 @@ func (im *instanceManager) autoStartInstances() {
 			// Local instance - call Start() directly
 			if err := inst.Start(); err != nil {
 				log.Printf("Failed to auto-start instance %s: %v", inst.Name, err)
+				continue
 			}
 		}
+		if group != "" {
+			groupRunning[group]++
+		}
+		started++
 	}
 }
 

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -12,6 +12,7 @@ import (
 	"llamactl/pkg/validation"
 	"log"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -69,6 +70,13 @@ type Handler struct {
 	httpClient      *http.Client
 	authStore       database.AuthStore
 	authMiddleware  *APIAuthMiddleware
+
+	// startMu serializes the evict→start→wait critical section in
+	// ensureInstanceRunning. Group quotas are check-then-act; without this,
+	// two concurrent requests can each see room (or evict the other's LRU)
+	// and start two models in the same group. Holding it through
+	// WaitForHealthy also sequences VRAM-heavy model loads on a shared GPU.
+	startMu sync.Mutex
 }
 
 // NewHandler creates a new Handler instance with the provided instance manager and configuration
@@ -110,6 +118,10 @@ func (h *Handler) ensureInstanceRunning(inst *instance.Instance, canStart bool, 
 	if !canStart {
 		return ErrInstanceNotRunning
 	}
+
+	// See Handler.startMu for why this whole section is serialized.
+	h.startMu.Lock()
+	defer h.startMu.Unlock()
 
 	options := inst.GetOptions()
 	if options == nil || options.OnDemandStart == nil || !*options.OnDemandStart {


### PR DESCRIPTION
## Problem

Three lifecycle bugs observed in real operation:

1. **Double-spawn / double-binding.** If a surviving llama-server was still bound to the instance port (crashed or previously-started instance), starting the instance spawned a *second* server on the same port — two copies of the model in VRAM at once.
2. **Boot-time VRAM storms.** With auto-restart, every persisted-running instance started at once, ignoring group and global running-instance limits — booting multiple large models simultaneously and spilling VRAM into system RAM.
3. **Broken "graceful" stop on Windows.** The stop path attempted to deliver Ctrl-C via `GenerateConsoleCtrlEvent`, which cannot reach the child in a service session, so the graceful path was misleading and stop behavior was effectively a force-kill with a 30 s grace.

## Changes

**`pkg/instance/process.go`**
- Port-in-use guard before spawn: wait up to 15 s (500 ms polls) for the instance port to be released; if still occupied, fail with a `netstat -ano | findstr <port>` hint instead of double-binding.
- Stdin pipe to the child. Stop sequence is now: close stdin (EOF is a shutdown request the backends honor) → platform interrupt → grace wait → force-kill.

**`pkg/instance/process_group_{unix,windows}.go`**
- Platform signal helpers; Windows side simplified to its reliable behavior (see below).

**`pkg/manager/lifecycle.go`**
- Idle reaper defers stopping an instance that has in-flight requests (the stop grace of 30 s is far too short for long generations).
- Auto-restart boot now enforces group and global running-instance limits: starts most-recently-used first and leaves the rest stopped (they start on demand).

**`pkg/manager/manager.go`, `pkg/server/handlers.go`**
- `startMu` serializes the evict → start → wait critical section in `ensureInstanceRunning`. Group quotas are check-then-act, so concurrent requests could otherwise each see room (or evict each other's LRU) and start two models in the same group; the lock also sequences VRAM-heavy model loads on a shared GPU.

**`c13238a` — drop the non-functional Windows Ctrl-C path**
Verified against the actual failure modes: direct `GenerateConsoleCtrlEvent` to the child PID fails with Win32 87; the shared-console group event reaches the caller, not the child; `AttachConsole` is access-denied; ConPTY `0x03` and stdin-EOF do not fire llama.cpp's handler. `setProcAttrs`/`signalStop` are back to no-ops (matching upstream), the `golang.org/x/sys` direct dependency is dropped, and the stop-path comments now state honestly that on Windows the force-kill is the reliable stop (with a shorter grace there).

## Verification

- `go build ./...`, `go test ./...` pass on Windows.
- Double-spawn guard exercised against a surviving process holding the port: start fails with the netstat hint, no second server in VRAM.
- Group/global boot limits: with `MaxRunningInstances` / group limits set, extra auto-restart instances stay stopped and start on demand.
- In-flight guard: idle timeout with active generation logs `timed out but has N in-flight request(s); deferring idle stop`.
- Windows stop: stop completes via the force-kill path within the short grace; no 30 s hang.
